### PR TITLE
Add options for setting OUTFILE, OUTFILE_PREFIX, OUTDIR, and OUTPUT

### DIFF
--- a/Cat-Scale.sh
+++ b/Cat-Scale.sh
@@ -36,13 +36,15 @@ fi
 # Force date format
 DTG=$(date +"%Y%m%d-%H%M")
 # Outfile name
-OUTFILE=$SHORTNAME-$DTG
+OUTFILE_PREFIX=${OUTFILE_PREFIX:-catscale_}
+OUTFILE=${OUTFILE:-$SHORTNAME-$DTG}
+OUTDIR=${OUTDIR:-catscale_out}
 
 #Define Global Variables
 oscheck=$(find /etc ! -path /etc -prune -name "*release*" -print0 | xargs -0 cat 2>/dev/null | tr [:upper:] [:lower:])
 osid=''
 uname=''
-OUTPUT=.
+OUTPUT=${OUTPUT:-.}
 
 ######################################################################################################
 ########################################### FUNCTIONS ################################################
@@ -83,36 +85,36 @@ starttheshow(){ #Production
 	echo " *                                  Linux Collection                                          *"
 	echo " **********************************************************************************************"
     
-	# Exit if catscale_out folder exit. 
-	if [ -d $OUTPUT/catscale_out ]; then
+	# Exit if $OUTDIR folder exists.
+	if [ -d $OUTPUT/$OUTDIR ]; then
 	 echo " "
 	 echo " ******************************************************"
-	 echo "  ERROR: Output path directory(catscale_out) already exists! " 
+	 echo "  ERROR: Output path directory($OUTDIR) already exists! "
 	 echo " ******************************************************"
 	 echo " "
 	 exit
 	fi
 
 	# Create output directory if does not exist and chmod it
-	mkdir $OUTPUT/catscale_out
-	chmod 600 $OUTPUT/catscale_out
-	mkdir $OUTPUT/catscale_out/Process_and_Network
-	mkdir $OUTPUT/catscale_out/Logs
-	mkdir $OUTPUT/catscale_out/System_Info
-	mkdir $OUTPUT/catscale_out/Persistence
-	mkdir $OUTPUT/catscale_out/User_Files
-	mkdir $OUTPUT/catscale_out/Misc
-	mkdir $OUTPUT/catscale_out/Docker
-	mkdir $OUTPUT/catscale_out/Podman
-	mkdir $OUTPUT/catscale_out/Virsh
+	mkdir $OUTPUT/$OUTDIR
+	chmod 600 $OUTPUT/$OUTDIR
+	mkdir $OUTPUT/$OUTDIR/Process_and_Network
+	mkdir $OUTPUT/$OUTDIR/Logs
+	mkdir $OUTPUT/$OUTDIR/System_Info
+	mkdir $OUTPUT/$OUTDIR/Persistence
+	mkdir $OUTPUT/$OUTDIR/User_Files
+	mkdir $OUTPUT/$OUTDIR/Misc
+	mkdir $OUTPUT/$OUTDIR/Docker
+	mkdir $OUTPUT/$OUTDIR/Podman
+	mkdir $OUTPUT/$OUTDIR/Virsh
 	# Print OS info into error log
 	echo " "
 	echo "Running Collection Scripts "
 	echo " "
-	echo oscheck: $oscheck > $OUTPUT/catscale_out/$OUTFILE-console-error-log.txt
-	echo Date : $(date) >> $OUTPUT/catscale_out/$OUTFILE-console-error-log.txt
-	echo "================================ Console Errors ================================" >> $OUTPUT/catscale_out/$OUTFILE-console-error-log.txt
-	echo Date : $(date) > $OUTPUT/catscale_out/System_Info/$OUTFILE-host-date-timezone.txt 
+	echo oscheck: $oscheck > $OUTPUT/$OUTDIR/$OUTFILE-console-error-log.txt
+	echo Date : $(date) >> $OUTPUT/$OUTDIR/$OUTFILE-console-error-log.txt
+	echo "================================ Console Errors ================================" >> $OUTPUT/$OUTDIR/$OUTFILE-console-error-log.txt
+	echo Date : $(date) > $OUTPUT/$OUTDIR/System_Info/$OUTFILE-host-date-timezone.txt
  }
  
 #
@@ -121,7 +123,7 @@ starttheshow(){ #Production
 #
 get_hidden_home_files(){ #Production
 
- grep -v "/nologin\|/sync\|/false" /etc/passwd | cut -f6 -d ':' | xargs -I {} find {} ! -path {} -prune -type f -name .\* -print0 | xargs -0 tar -czvf $OUTPUT/catscale_out/User_Files/hidden-user-home-dir.tar.gz  > $OUTPUT/catscale_out/User_Files/hidden-user-home-dir-list.txt
+ grep -v "/nologin\|/sync\|/false" /etc/passwd | cut -f6 -d ':' | xargs -I {} find {} ! -path {} -prune -type f -name .\* -print0 | xargs -0 tar -czvf $OUTPUT/$OUTDIR/User_Files/hidden-user-home-dir.tar.gz  > $OUTPUT/$OUTDIR/User_Files/hidden-user-home-dir-list.txt
 
 }
 
@@ -134,7 +136,7 @@ get_find_timeline(){ #Production
 		echo "Inode,Hard link Count,Full Path,Last Access,Last Modification,Last Status Change,File Creation,User,Group,File Permissions,File Size(bytes)"
 		find / -xdev -print0 | xargs -0 stat --printf="%i,%h,%n,%x,%y,%z,%w,%U,%G,%A,%s\n" 2>/dev/null
 		find /dev/shm -print0 | xargs -0 stat --printf="%i,%h,%n,%x,%y,%z,%w,%U,%G,%A,%s\n" 2>/dev/null
-	}> $OUTPUT/catscale_out/Misc/$OUTFILE-full-timeline.csv
+	}> $OUTPUT/$OUTDIR/Misc/$OUTFILE-full-timeline.csv
 	
 }
 
@@ -146,47 +148,47 @@ get_procinfo_GNU(){ #Production
 	echo "      Collecting Active Process..."
 	PS_FORMAT=user,pid,ppid,vsz,rss,tname,stat,stime,time,args
 	if ps axwwSo $PS_FORMAT &> /dev/null; then
-		ps axwwSo $PS_FORMAT > $OUTPUT/catscale_out/Process_and_Network/$OUTFILE-processes-axwwSo.txt
+		ps axwwSo $PS_FORMAT > $OUTPUT/$OUTDIR/Process_and_Network/$OUTFILE-processes-axwwSo.txt
 	elif ps auxSww &> /dev/null; then
-		ps auxSww > $OUTPUT/catscale_out/Process_and_Network/$OUTFILE-processes-auxSww.txt
+		ps auxSww > $OUTPUT/$OUTDIR/Process_and_Network/$OUTFILE-processes-auxSww.txt
 	elif ps auxww &> /dev/null; then
-		ps auxww > $OUTPUT/catscale_out/Process_and_Network/$OUTFILE-processes-auxww.txt
+		ps auxww > $OUTPUT/$OUTDIR/Process_and_Network/$OUTFILE-processes-auxww.txt
 	elif ps -eF &> /dev/null; then
-		ps -eF > $OUTPUT/catscale_out/Process_and_Network/$OUTFILE-processes-eF.txt
+		ps -eF > $OUTPUT/$OUTDIR/Process_and_Network/$OUTFILE-processes-eF.txt
 	elif ps -ef &> /dev/null; then
-		ps -ef > $OUTPUT/catscale_out/Process_and_Network/$OUTFILE-processes-ef.txt
+		ps -ef > $OUTPUT/$OUTDIR/Process_and_Network/$OUTFILE-processes-ef.txt
 	else
-		ps -e > $OUTPUT/catscale_out/Process_and_Network/$OUTFILE-processes-e.txt
+		ps -e > $OUTPUT/$OUTDIR/Process_and_Network/$OUTFILE-processes-e.txt
 	fi
 	
 
 	echo "      Getting the proc/*/status..."
-	find /proc -maxdepth 2 -wholename '/proc/[0-9]*/status' | xargs cat  >> $OUTPUT/catscale_out/Process_and_Network/$OUTFILE-process-details.txt
+	find /proc -maxdepth 2 -wholename '/proc/[0-9]*/status' | xargs cat  >> $OUTPUT/$OUTDIR/Process_and_Network/$OUTFILE-process-details.txt
 
 	echo "      Getting the process hashes..."
-	find -L /proc/[0-9]*/exe -print0 2>/dev/null | xargs -0 sha1sum 2>/dev/null > $OUTPUT/catscale_out/Process_and_Network/$OUTFILE-processhashes.txt	
+	find -L /proc/[0-9]*/exe -print0 2>/dev/null | xargs -0 sha1sum 2>/dev/null > $OUTPUT/$OUTDIR/Process_and_Network/$OUTFILE-processhashes.txt
 	
 	echo "      Getting the process symbolic links..."
-	find /proc/[0-9]*/exe -print0 2>/dev/null | xargs -0 ls -lh 2>/dev/null > $OUTPUT/catscale_out/Process_and_Network/$OUTFILE-process-exe-links.txt	
+	find /proc/[0-9]*/exe -print0 2>/dev/null | xargs -0 ls -lh 2>/dev/null > $OUTPUT/$OUTDIR/Process_and_Network/$OUTFILE-process-exe-links.txt
     
     echo "      Getting the process map_files hashes..."
-	find -L /proc/[0-9]*/map_files -type f -print0 2>/dev/null | xargs -0 sha1sum 2>/dev/null > $OUTPUT/catscale_out/Process_and_Network/$OUTFILE-process-map_files-link-hashes.txt
+	find -L /proc/[0-9]*/map_files -type f -print0 2>/dev/null | xargs -0 sha1sum 2>/dev/null > $OUTPUT/$OUTDIR/Process_and_Network/$OUTFILE-process-map_files-link-hashes.txt
     
     echo "      Getting the process map_files links..."
-	find /proc/[0-9]*/map_files -print0 2>/dev/null | xargs -0 ls -lh 2>/dev/null > $OUTPUT/catscale_out/Process_and_Network/$OUTFILE-process-map_files-links.txt
+	find /proc/[0-9]*/map_files -print0 2>/dev/null | xargs -0 ls -lh 2>/dev/null > $OUTPUT/$OUTDIR/Process_and_Network/$OUTFILE-process-map_files-links.txt
     
 	echo "      Getting the process fd links..."
-	find /proc/[0-9]*/fd -print0 2>/dev/null | xargs -0 ls -lh 2>/dev/null > $OUTPUT/catscale_out/Process_and_Network/$OUTFILE-process-fd-links.txt
+	find /proc/[0-9]*/fd -print0 2>/dev/null | xargs -0 ls -lh 2>/dev/null > $OUTPUT/$OUTDIR/Process_and_Network/$OUTFILE-process-fd-links.txt
 	
 	echo "      Getting the process cmdline..."
-	find /proc/[0-9]*/cmdline | xargs head 2>/dev/null > $OUTPUT/catscale_out/Process_and_Network/$OUTFILE-process-cmdline.txt
+	find /proc/[0-9]*/cmdline | xargs head 2>/dev/null > $OUTPUT/$OUTDIR/Process_and_Network/$OUTFILE-process-cmdline.txt
 
 	echo "      Getting the process environment variables..."
-	find /proc/[0-9]*/environ | xargs head 2>/dev/null > $OUTPUT/catscale_out/Process_and_Network/$OUTFILE-process-environment.txt
+	find /proc/[0-9]*/environ | xargs head 2>/dev/null > $OUTPUT/$OUTDIR/Process_and_Network/$OUTFILE-process-environment.txt
 
 	if which lsof &>/dev/null; then
 
-		lsof +c0 -M -R -V -w -n -P -e /run/user/1000/gvfs > $OUTPUT/catscale_out/Process_and_Network/$OUTFILE-lsof-list-open-files.txt
+		lsof +c0 -M -R -V -w -n -P -e /run/user/1000/gvfs > $OUTPUT/$OUTDIR/Process_and_Network/$OUTFILE-lsof-list-open-files.txt
 
   fi
 
@@ -197,19 +199,19 @@ get_procinfo_Solaris(){ #Production
 	#if output=$(ps -ef 2>/dev/null); then printf "%s\n" "$output" ; else echo no; fi
 	echo "      Collecting Active Process ..."
 	if ps -ef &> /dev/null; then
-		ps -ef > $OUTPUT/catscale_out/Process_and_Network/$OUTFILE-processes-ef.txt
+		ps -ef > $OUTPUT/$OUTDIR/Process_and_Network/$OUTFILE-processes-ef.txt
 	else
-		ps -e > $OUTPUT/catscale_out/Process_and_Network/$OUTFILE-processes-e.txt
+		ps -e > $OUTPUT/$OUTDIR/Process_and_Network/$OUTFILE-processes-e.txt
 	fi
 	
 	echo "      Getting the process hashes..."
-	find /proc/[0-9]*/object -name a.out | xargs sha1sum 2>/dev/null > $OUTPUT/catscale_out/Process_and_Network/$OUTFILE-processhashes.txt
+	find /proc/[0-9]*/object -name a.out | xargs sha1sum 2>/dev/null > $OUTPUT/$OUTDIR/Process_and_Network/$OUTFILE-processhashes.txt
 	
 	echo "      Getting the process cmdline..."
-	find /proc/[0-9]*/cmdline | xargs head 2>/dev/null > $OUTPUT/catscale_out/Process_and_Network/$OUTFILE-process-cmdline.txt
+	find /proc/[0-9]*/cmdline | xargs head 2>/dev/null > $OUTPUT/$OUTDIR/Process_and_Network/$OUTFILE-process-cmdline.txt
 	
 	if which lsof &>/dev/null; then
-		lsof -n -P -e /run/user/1000/gvfs > $OUTPUT/catscale_out/Process_and_Network/$OUTFILE-lsof-list-open-files.txt
+		lsof -n -P -e /run/user/1000/gvfs > $OUTPUT/$OUTDIR/Process_and_Network/$OUTFILE-lsof-list-open-files.txt
 	fi
 }
 
@@ -223,51 +225,51 @@ get_netinfo_GNU(){ #Production
 	#Get all network connections
 	echo "      Collecting Active Network Connections..."
 	if ss -anepo &>/dev/null; then
-		ss -anepo > $OUTPUT/catscale_out/Process_and_Network/$OUTFILE-ss-anepo.txt
+		ss -anepo > $OUTPUT/$OUTDIR/Process_and_Network/$OUTFILE-ss-anepo.txt
 
 	elif netstat -pvWanoee &>/dev/null; then
-		netstat -pvWanoee > $OUTPUT/catscale_out/Process_and_Network/$OUTFILE-netstat-pvWanoee.txt
+		netstat -pvWanoee > $OUTPUT/$OUTDIR/Process_and_Network/$OUTFILE-netstat-pvWanoee.txt
 
 	elif netstat -pvTanoee &>/dev/null; then
-		netstat -pvTanoee > $OUTPUT/catscale_out/Process_and_Network/$OUTFILE-netstat-pvTanoee.txt
+		netstat -pvTanoee > $OUTPUT/$OUTDIR/Process_and_Network/$OUTFILE-netstat-pvTanoee.txt
 
 	else
-		netstat -antup > $OUTPUT/catscale_out/Process_and_Network/$OUTFILE-netstat-antup.txt
-		netstat -an > $OUTPUT/catscale_out/Process_and_Network/$OUTFILE-netstat-an.txt
+		netstat -antup > $OUTPUT/$OUTDIR/Process_and_Network/$OUTFILE-netstat-antup.txt
+		netstat -an > $OUTPUT/$OUTDIR/Process_and_Network/$OUTFILE-netstat-an.txt
 
 	fi
 	
 	#Get ip and interface config
 	echo "      Collecting IP and Interface Config..."
 	if which ip &>/dev/null; then
-		ip a > $OUTPUT/catscale_out/Process_and_Network/$OUTFILE-ip-a.txt
+		ip a > $OUTPUT/$OUTDIR/Process_and_Network/$OUTFILE-ip-a.txt
 	else 
-		ifconfig -a > $OUTPUT/catscale_out/Process_and_Network/$OUTFILE-ifconfig.txt
+		ifconfig -a > $OUTPUT/$OUTDIR/Process_and_Network/$OUTFILE-ifconfig.txt
 	fi
 	
 	#Get routing table
 	echo "      Collecting Routing Table..."
 	if ip route &>/dev/null; then
-		ip route > $OUTPUT/catscale_out/Process_and_Network/$OUTFILE-routetable.txt
+		ip route > $OUTPUT/$OUTDIR/Process_and_Network/$OUTFILE-routetable.txt
 	else
-		netstat -rn > $OUTPUT/catscale_out/Process_and_Network/$OUTFILE-routetable.txt
+		netstat -rn > $OUTPUT/$OUTDIR/Process_and_Network/$OUTFILE-routetable.txt
 	fi
 	
 	#Get iptables. Firewall rules.
 	echo "      Collecting IPtables..."
 
-	iptables -L -n -v --line-numbers > $OUTPUT/catscale_out/Process_and_Network/$OUTFILE-iptables-numerical.txt
+	iptables -L -n -v --line-numbers > $OUTPUT/$OUTDIR/Process_and_Network/$OUTFILE-iptables-numerical.txt
   
-	iptables -L > $OUTPUT/catscale_out/Process_and_Network/$OUTFILE-iptables.txt
+	iptables -L > $OUTPUT/$OUTDIR/Process_and_Network/$OUTFILE-iptables.txt
 
 	
 
 	#Get SeLinux Verbose information
 	if which sestatus &>/dev/null; then
 		echo "      Collecting SELinux status..."
-		sestatus -v > $OUTPUT/catscale_out/Process_and_Network/$OUTFILE-selinux.txt
+		sestatus -v > $OUTPUT/$OUTDIR/Process_and_Network/$OUTFILE-selinux.txt
 		echo "      Collecting SELinux booleans..."
-		getsebool -a > $OUTPUT/catscale_out/Process_and_Network/$OUTFILE-getsebool.txt
+		getsebool -a > $OUTPUT/$OUTDIR/Process_and_Network/$OUTFILE-getsebool.txt
 	fi
 	
 	
@@ -276,28 +278,28 @@ get_netinfo_Solaris(){ #Production
 	
 	#Get network connections
 	echo "      Collecting Active Network Connections..."
-	netstat -an > $OUTPUT/catscale_out/Process_and_Network/$OUTFILE-netstat-an.txt
+	netstat -an > $OUTPUT/$OUTDIR/Process_and_Network/$OUTFILE-netstat-an.txt
 
 	#Get ip and interface config
 	echo "      Collecting IP and Interface Config..."
-	ifconfig -a > $OUTPUT/catscale_out/Process_and_Network/$OUTFILE-ifconfig.txt
+	ifconfig -a > $OUTPUT/$OUTDIR/Process_and_Network/$OUTFILE-ifconfig.txt
 	
 	#Get ipf table. Firewall rules. Might need further testing and optimization 
 	if which ipfstat &>/dev/null; then
 		echo "      Collecting ipf tables..."
-		ipfstat -ion > $OUTPUT/catscale_out/Process_and_Network/$OUTFILE-ipftables.txt
+		ipfstat -ion > $OUTPUT/$OUTDIR/Process_and_Network/$OUTFILE-ipftables.txt
 	fi
 
 	#Get routing table
 	echo "      Collecting Routing Table..."
-	netstat -rn > $OUTPUT/catscale_out/Process_and_Network/$OUTFILE-routetable.txt
+	netstat -rn > $OUTPUT/$OUTDIR/Process_and_Network/$OUTFILE-routetable.txt
 	
 	#Get SeLinux Verbose information
 	if which sestatus &>/dev/null; then
 		echo "      Collecting SELinux status..."
-		sestatus -v > $OUTPUT/catscale_out/Process_and_Network/$OUTFILE-selinux.txt
+		sestatus -v > $OUTPUT/$OUTDIR/Process_and_Network/$OUTFILE-selinux.txt
 		echo "      Collecting SELinux booleans..."
-		getsebool -a > $OUTPUT/catscale_out/Process_and_Network/$OUTFILE-getsebool.txt
+		getsebool -a > $OUTPUT/$OUTDIR/Process_and_Network/$OUTFILE-getsebool.txt
 	fi
 
 }
@@ -312,10 +314,10 @@ get_config_GNU(){ #Production
 	files="( -iname yum* -o -iname apt* -o -iname hosts* -o -iname passwd \
 	-o -iname sudoers* -o -iname cron* -o -iname ssh* -o -iname rc* -o -iname systemd* -o -iname anacron  \
 	-o -iname inittab -o -iname init.d -o -iname profile* -o -iname bash* )"
-    find /etc/ -type f,d $files -print0 | xargs -0 tar -czvf $OUTPUT/catscale_out/System_Info/$OUTFILE-etc-key-files.tar.gz 2>/dev/null > $OUTPUT/catscale_out/System_Info/$OUTFILE-etc-key-files-list.txt
+    find /etc/ -type f,d $files -print0 | xargs -0 tar -czvf $OUTPUT/$OUTDIR/System_Info/$OUTFILE-etc-key-files.tar.gz 2>/dev/null > $OUTPUT/$OUTDIR/System_Info/$OUTFILE-etc-key-files-list.txt
     
     # Get files that were modified in the last 90 days, collect all files, including symbolic links
-    find /etc/ -type f -mtime -90 -print0 | xargs -0 tar -czvf $OUTPUT/catscale_out/System_Info/$OUTFILE-etc-modified-files.tar.gz --dereference --hard-dereference 2>/dev/null > $OUTPUT/catscale_out/System_Info/$OUTFILE-etc-modified-files-list.txt
+    find /etc/ -type f -mtime -90 -print0 | xargs -0 tar -czvf $OUTPUT/$OUTDIR/System_Info/$OUTFILE-etc-modified-files.tar.gz --dereference --hard-dereference 2>/dev/null > $OUTPUT/$OUTDIR/System_Info/$OUTFILE-etc-modified-files-list.txt
 	
 }
 
@@ -325,10 +327,10 @@ get_config_Solaris(){ #Production
 	files="( ( -iname yum* -o -iname apt* -o -iname hosts* -o -iname passwd \
 	-o -iname sudoers* -o -iname cron* -o -iname ssh* -o -iname rc* -o -iname systemd* -o -iname anacron  \
 	-o -iname inittab -o -iname init.d -o -iname profile* -o -iname bash* ) -a ( -type f -o -type d ) )"
-	find /etc/ $files -print0 | xargs -0 tar -czvf $OUTPUT/catscale_out/System_Info/$OUTFILE-etc-key-files.tar.gz 2>/dev/null > $OUTPUT/catscale_out/System_Info/$OUTFILE-etc-key-files-list.txt 
+	find /etc/ $files -print0 | xargs -0 tar -czvf $OUTPUT/$OUTDIR/System_Info/$OUTFILE-etc-key-files.tar.gz 2>/dev/null > $OUTPUT/$OUTDIR/System_Info/$OUTFILE-etc-key-files-list.txt
     
     # Get files that were modified in the last 90 days, collect all files, including symbolic links
-    find /etc/ -mtime -90 -print0 | xargs -0 tar -czvf $OUTPUT/catscale_out/System_Info/$OUTFILE-etc-modified-files.tar.gz 2>/dev/null > $OUTPUT/catscale_out/System_Info/$OUTFILE-etc-modified-files-list.txt 
+    find /etc/ -mtime -90 -print0 | xargs -0 tar -czvf $OUTPUT/$OUTDIR/System_Info/$OUTFILE-etc-modified-files.tar.gz 2>/dev/null > $OUTPUT/$OUTDIR/System_Info/$OUTFILE-etc-modified-files-list.txt
 	
 }
 
@@ -338,61 +340,61 @@ get_config_Solaris(){ #Production
 get_logs_GNU(){ #Production
 
 	echo "      Collecting logged in users..."
-	who -a > $OUTPUT/catscale_out/Logs/$OUTFILE-who.txt
+	who -a > $OUTPUT/$OUTDIR/Logs/$OUTFILE-who.txt
 	
 	echo "      Collecting 'w'..."
-	w > $OUTPUT/catscale_out/Logs/$OUTFILE-whoandwhat.txt
+	w > $OUTPUT/$OUTDIR/Logs/$OUTFILE-whoandwhat.txt
 
 	echo "      Collecting bad logins(btmp)..."
-	find /var/log -maxdepth 1 -type f -name "btmp*" -exec last -Faiwx -f {} \; > $OUTPUT/catscale_out/Logs/$OUTFILE-last-btmp.txt
+	find /var/log -maxdepth 1 -type f -name "btmp*" -exec last -Faiwx -f {} \; > $OUTPUT/$OUTDIR/Logs/$OUTFILE-last-btmp.txt
 	
 	echo "      Collecting Active Logon information(utmp)..."
-	find / -maxdepth 2 -type f -name "utmp*" -exec last -Faiwx -f {} \; > $OUTPUT/catscale_out/Logs/$OUTFILE-last-utmp.txt
-	find / -maxdepth 2 -type f -name "utmp*" -exec utmpdump {} \; > $OUTPUT/catscale_out/Logs/$OUTFILE-last-utmpdump.txt
+	find / -maxdepth 2 -type f -name "utmp*" -exec last -Faiwx -f {} \; > $OUTPUT/$OUTDIR/Logs/$OUTFILE-last-utmp.txt
+	find / -maxdepth 2 -type f -name "utmp*" -exec utmpdump {} \; > $OUTPUT/$OUTDIR/Logs/$OUTFILE-last-utmpdump.txt
 	
 	echo "      Collecting Historic Logon information(wtmp)..."
-	find /var/log -maxdepth 1 -type f -name "wtmp*" -exec last -Faiwx -f {} \; > $OUTPUT/catscale_out/Logs/$OUTFILE-last-wtmp.txt
+	find /var/log -maxdepth 1 -type f -name "wtmp*" -exec last -Faiwx -f {} \; > $OUTPUT/$OUTDIR/Logs/$OUTFILE-last-wtmp.txt
 	
 	echo "      Collecting lastlog..."
-	lastlog > $OUTPUT/catscale_out/Logs/$OUTFILE-lastlog.txt
+	lastlog > $OUTPUT/$OUTDIR/Logs/$OUTFILE-lastlog.txt
 
 	echo "      Checking passwd integrity"
-	pwck -r > $OUTPUT/catscale_out/Logs/$OUTFILE-passwd-check.txt
+	pwck -r > $OUTPUT/$OUTDIR/Logs/$OUTFILE-passwd-check.txt
 
 	#Collect all files in in /var/log folder.
 	echo "      Collecting /var/log/ folder..."
-	tar -czvf $OUTPUT/catscale_out/Logs/$OUTFILE-var-log.tar.gz --dereference --hard-dereference --sparse /var/log > $OUTPUT/catscale_out/Logs/$OUTFILE-var-log-list.txt
+	tar -czvf $OUTPUT/$OUTDIR/Logs/$OUTFILE-var-log.tar.gz --dereference --hard-dereference --sparse /var/log > $OUTPUT/$OUTDIR/Logs/$OUTFILE-var-log-list.txt
 
 	#Collect all files in in /var/crash folder.
 	echo "      Collecting /var/crash/ folder..."
-    tar -czvf $OUTPUT/catscale_out/Logs/$OUTFILE-var-crash.tar.gz --dereference --hard-dereference --sparse /var/crash > $OUTPUT/catscale_out/Logs/$OUTFILE-var-crash-list.txt
+    tar -czvf $OUTPUT/$OUTDIR/Logs/$OUTFILE-var-crash.tar.gz --dereference --hard-dereference --sparse /var/crash > $OUTPUT/$OUTDIR/Logs/$OUTFILE-var-crash-list.txt
 	
 }
 get_logs_Solaris(){ #Production
 
 	echo "      Collecting logged in users..."
-	who -a > $OUTPUT/catscale_out/Logs/$OUTFILE-who.txt
+	who -a > $OUTPUT/$OUTDIR/Logs/$OUTFILE-who.txt
 	
 	echo "      Collecting 'w'..."
-	w > $OUTPUT/catscale_out/Logs/$OUTFILE-whoandwhat.txt
+	w > $OUTPUT/$OUTDIR/Logs/$OUTFILE-whoandwhat.txt
 
 	echo "      Collecting bad logins(btmp)..."
-	find /var/adm -type f -name "btmp*" -exec last -f {} \; > $OUTPUT/catscale_out/Logs/$OUTFILE-last-btmpx.txt
+	find /var/adm -type f -name "btmp*" -exec last -f {} \; > $OUTPUT/$OUTDIR/Logs/$OUTFILE-last-btmpx.txt
 	
 	echo "      Collecting Historic Logon information(wtmp)..."
-	find /var/adm -type f -name "wtmp*" -exec last -f {} \; > $OUTPUT/catscale_out/Logs/$OUTFILE-last-wtmpx.txt
+	find /var/adm -type f -name "wtmp*" -exec last -f {} \; > $OUTPUT/$OUTDIR/Logs/$OUTFILE-last-wtmpx.txt
 
 	#Collect all files in in /var/log folder.
 	echo "      Collecting /var/log/ folder..."
-	find /var/log -type f -print0 | xargs -0 tar -czfv $OUTPUT/catscale_out/Logs/$OUTFILE-var-log.tar.gz > $OUTPUT/catscale_out/Logs/$OUTFILE-var-log-list.txt
+	find /var/log -type f -print0 | xargs -0 tar -czfv $OUTPUT/$OUTDIR/Logs/$OUTFILE-var-log.tar.gz > $OUTPUT/$OUTDIR/Logs/$OUTFILE-var-log-list.txt
 	
 	#Collect all files in in /var/adm folder.
 	echo "      Collecting /var/adm/ folder..."
-	find /var/adm -type f -print0 | xargs -0 tar -czfv $OUTPUT/catscale_out/Logs/$OUTFILE-var-adm.tar.gz  > $OUTPUT/catscale_out/Logs/$OUTFILE-var-adm-list.txt
+	find /var/adm -type f -print0 | xargs -0 tar -czfv $OUTPUT/$OUTDIR/Logs/$OUTFILE-var-adm.tar.gz  > $OUTPUT/$OUTDIR/Logs/$OUTFILE-var-adm-list.txt
 
 	#Collect all files in in /var/crash folder.
 	echo "      Collecting /var/crash/ folder..."
-	find /var/crash -type f -print0 | xargs -0 tar -czfv $OUTPUT/catscale_out/Logs/$OUTFILE-var-crash.tar.gz  > $OUTPUT/catscale_out/Logs/$OUTFILE-var-crash-list.txt
+	find /var/crash -type f -print0 | xargs -0 tar -czfv $OUTPUT/$OUTDIR/Logs/$OUTFILE-var-crash.tar.gz  > $OUTPUT/$OUTDIR/Logs/$OUTFILE-var-crash-list.txt
 
 }
 
@@ -403,7 +405,7 @@ get_logs_Solaris(){ #Production
 get_sshkeynhosts(){ #Production
 	
 	echo "      Collecting .ssh folder..."
-	find / -xdev -type d -name .ssh -print0 | xargs -0 tar -czvf $OUTPUT/catscale_out/Process_and_Network/$OUTFILE-ssh-folders.tar.gz > $OUTPUT/catscale_out/Process_and_Network/$OUTFILE-ssh-folders-list.txt
+	find / -xdev -type d -name .ssh -print0 | xargs -0 tar -czvf $OUTPUT/$OUTDIR/Process_and_Network/$OUTFILE-ssh-folders.tar.gz > $OUTPUT/$OUTDIR/Process_and_Network/$OUTFILE-ssh-folders-list.txt
 
 }
 
@@ -414,67 +416,67 @@ get_sshkeynhosts(){ #Production
 get_systeminfo_GNU(){ #Production
 
 	echo "      Collecting Memory info..."
-	cat /proc/meminfo > $OUTPUT/catscale_out/System_Info/$OUTFILE-meminfo.txt
+	cat /proc/meminfo > $OUTPUT/$OUTDIR/System_Info/$OUTFILE-meminfo.txt
 	
 	echo "      Collecting CPU info..."
-	cat /proc/cpuinfo > $OUTPUT/catscale_out/System_Info/$OUTFILE-cpuinfo.txt
+	cat /proc/cpuinfo > $OUTPUT/$OUTDIR/System_Info/$OUTFILE-cpuinfo.txt
 	
 	echo "      Collecting df..."
-	df > $OUTPUT/catscale_out/System_Info/$OUTFILE-df.txt
+	df > $OUTPUT/$OUTDIR/System_Info/$OUTFILE-df.txt
 	
 	echo "      Collecting mount..."
-	mount > $OUTPUT/catscale_out/System_Info/$OUTFILE-mount.txt
+	mount > $OUTPUT/$OUTDIR/System_Info/$OUTFILE-mount.txt
 	
 	echo "      Collecting attached USB device info..."
-	lsusb -v > $OUTPUT/catscale_out/System_Info/$OUTFILE-lsusb.txt
+	lsusb -v > $OUTPUT/$OUTDIR/System_Info/$OUTFILE-lsusb.txt
 
 	echo "      Collecting kernel release..."	
-	find /etc ! -path /etc -prune -name "*release*" -print0 | xargs -0 cat 2>/dev/null > $OUTPUT/catscale_out/System_Info/$OUTFILE-release.txt
-	echo -n "KERNELVERSION(uname -r)=" >> $OUTPUT/catscale_out/System_Info/$OUTFILE-release.txt
-	uname -r >> $OUTPUT/catscale_out/System_Info/$OUTFILE-release.txt
+	find /etc ! -path /etc -prune -name "*release*" -print0 | xargs -0 cat 2>/dev/null > $OUTPUT/$OUTDIR/System_Info/$OUTFILE-release.txt
+	echo -n "KERNELVERSION(uname -r)=" >> $OUTPUT/$OUTDIR/System_Info/$OUTFILE-release.txt
+	uname -r >> $OUTPUT/$OUTDIR/System_Info/$OUTFILE-release.txt
 
 	echo "      Collecting lsmod..."
-	lsmod > $OUTPUT/catscale_out/System_Info/$OUTFILE-lsmod.txt
+	lsmod > $OUTPUT/$OUTDIR/System_Info/$OUTFILE-lsmod.txt
 	
 	echo "      Collecting modinfo..."
-	for i in `lsmod | awk '{print $1}' | sed '/Module/d'`; do echo -e "\nModule: $i"; modinfo $i ; done > $OUTPUT/catscale_out/System_Info/$OUTFILE-modinfo.txt
+	for i in `lsmod | awk '{print $1}' | sed '/Module/d'`; do echo -e "\nModule: $i"; modinfo $i ; done > $OUTPUT/$OUTDIR/System_Info/$OUTFILE-modinfo.txt
 
 	echo "      Collecting loaded modules..."
-	for i in `lsmod | awk '{print $1}' | sed '/Module/d'`; do modinfo $i | grep "filename:" | awk '{print $2}' | xargs -I{} sha1sum {} ; done > $OUTPUT/catscale_out/System_Info/$OUTFILE-module-sha1.txt
+	for i in `lsmod | awk '{print $1}' | sed '/Module/d'`; do modinfo $i | grep "filename:" | awk '{print $2}' | xargs -I{} sha1sum {} ; done > $OUTPUT/$OUTDIR/System_Info/$OUTFILE-module-sha1.txt
 	
 	echo "      Collecting proc/modules..."
-	cat '/proc/modules' > $OUTPUT/catscale_out/System_Info/$OUTFILE-procmod.txt
+	cat '/proc/modules' > $OUTPUT/$OUTDIR/System_Info/$OUTFILE-procmod.txt
 	
 	echo "      Collecting sudo config..."
-	sudo -V > $OUTPUT/catscale_out/System_Info/$OUTFILE-sudo.txt
+	sudo -V > $OUTPUT/$OUTDIR/System_Info/$OUTFILE-sudo.txt
 
 	echo "      Collecting dmesg..."
-	dmesg -T > $OUTPUT/catscale_out/System_Info/$OUTFILE-dmesg.txt
+	dmesg -T > $OUTPUT/$OUTDIR/System_Info/$OUTFILE-dmesg.txt
 
 
 }
 get_systeminfo_Solaris(){ #Production
 
 	echo "      Collecting Memory info..."
-	vmstat -p > $OUTPUT/catscale_out/System_Info/$OUTFILE-meminfo.txt
-	prstat -s size 1 1 > $OUTPUT/catscale_out/System_Info/$OUTFILE-ProcMemUsage.txt
-	ipcs -a > $OUTPUT/catscale_out/System_Info/$OUTFILE-SharedMemAndSemaphores.txt
+	vmstat -p > $OUTPUT/$OUTDIR/System_Info/$OUTFILE-meminfo.txt
+	prstat -s size 1 1 > $OUTPUT/$OUTDIR/System_Info/$OUTFILE-ProcMemUsage.txt
+	ipcs -a > $OUTPUT/$OUTDIR/System_Info/$OUTFILE-SharedMemAndSemaphores.txt
 		
 	echo "      Collecting CPU info..."
-	prtdiag -v > $OUTPUT/catscale_out/System_Info/$OUTFILE-cpuinfo.txt
-	psrinfo -v >> $OUTPUT/catscale_out/System_Info/$OUTFILE-cpuinfo.txt
+	prtdiag -v > $OUTPUT/$OUTDIR/System_Info/$OUTFILE-cpuinfo.txt
+	psrinfo -v >> $OUTPUT/$OUTDIR/System_Info/$OUTFILE-cpuinfo.txt
 	
 	echo "      Collecting df..."
-	df > $OUTPUT/catscale_out/System_Info/$OUTFILE-df.txt
+	df > $OUTPUT/$OUTDIR/System_Info/$OUTFILE-df.txt
 	
 	echo "      Collecting attached USB device info..."
-	rmformat > $OUTPUT/catscale_out/System_Info/$OUTFILE-removeblemedia.txt
+	rmformat > $OUTPUT/$OUTDIR/System_Info/$OUTFILE-removeblemedia.txt
 	
 	echo "      Collecting kernel release..."		
-	find /etc ! -path /etc -prune -name "*release*" -print0 | xargs -0 cat 2>/dev/null > $OUTPUT/catscale_out/System_Info/$OUTFILE-release.txt
+	find /etc ! -path /etc -prune -name "*release*" -print0 | xargs -0 cat 2>/dev/null > $OUTPUT/$OUTDIR/System_Info/$OUTFILE-release.txt
 
 	echo "      Collecting loaded modules..."
-	modinfo -ao namedesc,state,loadcnt,path > $OUTPUT/catscale_out/System_Info/$OUTFILE-modules.txt	
+	modinfo -ao namedesc,state,loadcnt,path > $OUTPUT/$OUTDIR/System_Info/$OUTFILE-modules.txt
 	
 }
 
@@ -484,56 +486,56 @@ get_systeminfo_Solaris(){ #Production
 get_docker_info(){ #Testing
 	if which docker &>/dev/null; then
 		echo "      Collecting Docker info..."
-		docker container ls --all --size > $OUTPUT/catscale_out/Docker/$OUTFILE-docker-container-ls-all-size.txt
-		docker image ls --all > $OUTPUT/catscale_out/Docker/$OUTFILE-docker-image-ls-all.txt
-		docker info > $OUTPUT/catscale_out/Docker/$OUTFILE-docker-info.txt
+		docker container ls --all --size > $OUTPUT/$OUTDIR/Docker/$OUTFILE-docker-container-ls-all-size.txt
+		docker image ls --all > $OUTPUT/$OUTDIR/Docker/$OUTFILE-docker-image-ls-all.txt
+		docker info > $OUTPUT/$OUTDIR/Docker/$OUTFILE-docker-info.txt
 		docker container ps --all -q | while read line; do 
-			docker inspect $line > $OUTPUT/catscale_out/Docker/$OUTFILE-docker-inspect-$line.txt
-			docker container top $line > $OUTPUT/catscale_out/Docker/$OUTFILE-docker-top-$line.txt
-			docker container logs $line > $OUTPUT/catscale_out/Docker/$OUTFILE-docker-container-logs-$line.txt
-			docker container port $line > $OUTPUT/catscale_out/Docker/$OUTFILE-docker-container-port-$line.txt
-			docker container diff $line > $OUTPUT/catscale_out/Docker/$OUTFILE-docker-container-diff-$line.txt
+			docker inspect $line > $OUTPUT/$OUTDIR/Docker/$OUTFILE-docker-inspect-$line.txt
+			docker container top $line > $OUTPUT/$OUTDIR/Docker/$OUTFILE-docker-top-$line.txt
+			docker container logs $line > $OUTPUT/$OUTDIR/Docker/$OUTFILE-docker-container-logs-$line.txt
+			docker container port $line > $OUTPUT/$OUTDIR/Docker/$OUTFILE-docker-container-port-$line.txt
+			docker container diff $line > $OUTPUT/$OUTDIR/Docker/$OUTFILE-docker-container-diff-$line.txt
 		done 2>/dev/null
 		docker network ls | sed 1d | cut -d" " -f 1 | while read line; do 
-			docker network inspect $line > $OUTPUT/catscale_out/Docker/$OUTFILE-docker-network-inspect-$line.txt
+			docker network inspect $line > $OUTPUT/$OUTDIR/Docker/$OUTFILE-docker-network-inspect-$line.txt
 		done 2>/dev/null
-		docker version > $OUTPUT/catscale_out/Docker/$OUTFILE-docker-version.txt
+		docker version > $OUTPUT/$OUTDIR/Docker/$OUTFILE-docker-version.txt
 	fi
 	if which podman &>/dev/null; then
 		echo "      Collecting Podman info..."
-		podman container ls --all --size > $OUTPUT/catscale_out/Podman/$OUTFILE-podman-container-ls-all-size.txt
-		podman image ls --all > $OUTPUT/catscale_out/Podman/$OUTFILE-podman-image-ls-all.txt
-		podman info > $OUTPUT/catscale_out/Podman/$OUTFILE-podman-info.txt
+		podman container ls --all --size > $OUTPUT/$OUTDIR/Podman/$OUTFILE-podman-container-ls-all-size.txt
+		podman image ls --all > $OUTPUT/$OUTDIR/Podman/$OUTFILE-podman-image-ls-all.txt
+		podman info > $OUTPUT/$OUTDIR/Podman/$OUTFILE-podman-info.txt
 		podman container ps --all -q | while read line; do
-			podman inspect $line > $OUTPUT/catscale_out/Podman/$OUTFILE-podman-inspect-$line.txt
-			podman container top $line > $OUTPUT/catscale_out/Podman/$OUTFILE-podman-top-$line.txt
-			podman container logs $line > $OUTPUT/catscale_out/Podman/$OUTFILE-podman-container-logs-$line.txt
-			podman container port $line > $OUTPUT/catscale_out/Podman/$OUTFILE-podman-container-port-$line.txt
-			podman container diff $line > $OUTPUT/catscale_out/Podman/$OUTFILE-podman-container-diff-$line.txt
+			podman inspect $line > $OUTPUT/$OUTDIR/Podman/$OUTFILE-podman-inspect-$line.txt
+			podman container top $line > $OUTPUT/$OUTDIR/Podman/$OUTFILE-podman-top-$line.txt
+			podman container logs $line > $OUTPUT/$OUTDIR/Podman/$OUTFILE-podman-container-logs-$line.txt
+			podman container port $line > $OUTPUT/$OUTDIR/Podman/$OUTFILE-podman-container-port-$line.txt
+			podman container diff $line > $OUTPUT/$OUTDIR/Podman/$OUTFILE-podman-container-diff-$line.txt
 		done 2>/dev/null
 		podman network ls | sed 1d | cut -d" " -f 1 | while read line; do
-			podman network inspect $line > $OUTPUT/catscale_out/Podman/$OUTFILE-podman-network-inspect-$line.txt
+			podman network inspect $line > $OUTPUT/$OUTDIR/Podman/$OUTFILE-podman-network-inspect-$line.txt
 		done 2>/dev/null
-		podman version > $OUTPUT/catscale_out/Podman/$OUTFILE-podman-version.txt
+		podman version > $OUTPUT/$OUTDIR/Podman/$OUTFILE-podman-version.txt
 	fi
 	if which virsh &>/dev/null; then
 		echo "      Collecting Virsh info..."
-		virsh list --all > $OUTPUT/catscale_out/Virsh/$OUTFILE-virsh-list-all.txt
+		virsh list --all > $OUTPUT/$OUTDIR/Virsh/$OUTFILE-virsh-list-all.txt
 		virsh list --name | while read line; do 
-			virsh domifaddr $line > $OUTPUT/catscale_out/Virsh/$OUTFILE-virsh-domifaddr-$line.txt
-			virsh dominfo $line > $OUTPUT/catscale_out/Virsh/$OUTFILE-virsh-dominfo-$line.txt
-			virsh dommemstat $line > $OUTPUT/catscale_out/Virsh/$OUTFILE-virsh-dommemstat-$line.txt
-			virsh snapshot-list $line > $OUTPUT/catscale_out/Virsh/$OUTFILE-virsh-snapshot-list-$line.txt
-			virsh vcpuinfo $line > $OUTPUT/catscale_out/Virsh/$OUTFILE-virsh-vcpuinfo-$line.txt
+			virsh domifaddr $line > $OUTPUT/$OUTDIR/Virsh/$OUTFILE-virsh-domifaddr-$line.txt
+			virsh dominfo $line > $OUTPUT/$OUTDIR/Virsh/$OUTFILE-virsh-dominfo-$line.txt
+			virsh dommemstat $line > $OUTPUT/$OUTDIR/Virsh/$OUTFILE-virsh-dommemstat-$line.txt
+			virsh snapshot-list $line > $OUTPUT/$OUTDIR/Virsh/$OUTFILE-virsh-snapshot-list-$line.txt
+			virsh vcpuinfo $line > $OUTPUT/$OUTDIR/Virsh/$OUTFILE-virsh-vcpuinfo-$line.txt
 		done 2>/dev/null
-		virsh net-list --all > $OUTPUT/catscale_out/Virsh/$OUTFILE-virsh-net-list-all.txt
+		virsh net-list --all > $OUTPUT/$OUTDIR/Virsh/$OUTFILE-virsh-net-list-all.txt
 		virsh net-list --all --name | while read line; do 
-			virsh net-info $line > $OUTPUT/catscale_out/Virsh/$OUTFILE-virsh-net-info-$line.txt
-			virsh net-dhcp-leases $line > $OUTPUT/catscale_out/Virsh/$OUTFILE-virsh-net-dhcp-leases-$line.txt
+			virsh net-info $line > $OUTPUT/$OUTDIR/Virsh/$OUTFILE-virsh-net-info-$line.txt
+			virsh net-dhcp-leases $line > $OUTPUT/$OUTDIR/Virsh/$OUTFILE-virsh-net-dhcp-leases-$line.txt
 		done 2>/dev/null
-		virsh nodeinfo > $OUTPUT/catscale_out/Virsh/$OUTFILE-virsh-nodeinfo.txt
-		virsh pool-list --all > $OUTPUT/catscale_out/Virsh/$OUTFILE-virsh-pool-list-all.txt
-		virt-top -n 1 > $OUTPUT/catscale_out/Virsh/$OUTFILE-virt-top-n-1.txt
+		virsh nodeinfo > $OUTPUT/$OUTDIR/Virsh/$OUTFILE-virsh-nodeinfo.txt
+		virsh pool-list --all > $OUTPUT/$OUTDIR/Virsh/$OUTFILE-virsh-pool-list-all.txt
+		virt-top -n 1 > $OUTPUT/$OUTDIR/Virsh/$OUTFILE-virt-top-n-1.txt
 	fi
 }
 
@@ -544,16 +546,16 @@ get_packageinfo_GNU(){ #Production
 
 	echo "      Collecting installed package info..."
 	if which dpkg &>/dev/null; then
-		dpkg --list > $OUTPUT/catscale_out/System_Info/$OUTFILE-deb-packages.txt
+		dpkg --list > $OUTPUT/$OUTDIR/System_Info/$OUTFILE-deb-packages.txt
 	else 
-		rpm -qa > $OUTPUT/catscale_out/System_Info/$OUTFILE-rpm-packages.txt
+		rpm -qa > $OUTPUT/$OUTDIR/System_Info/$OUTFILE-rpm-packages.txt
 	fi
 	
 }
 get_packageinfo_Solaris(){ #Production
 
 	echo "      Collecting installed package info..."
-	pkginfo > $OUTPUT/catscale_out/System_Info/$OUTFILE-solaris-packages.txt
+	pkginfo > $OUTPUT/$OUTDIR/System_Info/$OUTFILE-solaris-packages.txt
 	
 }
 
@@ -563,21 +565,21 @@ get_packageinfo_Solaris(){ #Production
 get_startup_files_GNU(){ #Production
 
 	echo "      Collecting service status all..."
-	echo "This file might be empty as Latest versions of Red Hat, Fedora and Centos do not use service command. If this is empty please review systemctl file. " > $OUTPUT/catscale_out/Persistence/$OUTFILE-service_status.txt
-	service --status-all >> $OUTPUT/catscale_out/Persistence/$OUTFILE-service_status.txt
-	systemctl --all --type=service > $OUTPUT/catscale_out/Persistence/$OUTFILE-systemctl_service_status.txt
+	echo "This file might be empty as Latest versions of Red Hat, Fedora and Centos do not use service command. If this is empty please review systemctl file. " > $OUTPUT/$OUTDIR/Persistence/$OUTFILE-service_status.txt
+	service --status-all >> $OUTPUT/$OUTDIR/Persistence/$OUTFILE-service_status.txt
+	systemctl --all --type=service > $OUTPUT/$OUTDIR/Persistence/$OUTFILE-systemctl_service_status.txt
 	
 	echo "      Collecting status for all installed unit files..."
-	systemctl list-unit-files >> $OUTPUT/catscale_out/Persistence/$OUTFILE-systemctl_all.txt
+	systemctl list-unit-files >> $OUTPUT/$OUTDIR/Persistence/$OUTFILE-systemctl_all.txt
 
 	echo "      Collecting systemd..." 
-	find /etc/systemd/ -name "*.service" -print0 | xargs -0 cat > $OUTPUT/catscale_out/Persistence/$OUTFILE-persistence-systemdlist.txt
+	find /etc/systemd/ -name "*.service" -print0 | xargs -0 cat > $OUTPUT/$OUTDIR/Persistence/$OUTFILE-persistence-systemdlist.txt
 
 }
 get_startup_files_Solaris(){ #Production
 
 	echo "      Collecting service status all..."
-	svcs -a > $OUTPUT/catscale_out/Persistence/$OUTFILE-service_status.txt
+	svcs -a > $OUTPUT/$OUTDIR/Persistence/$OUTFILE-service_status.txt
 	
 }
 
@@ -588,26 +590,26 @@ get_startup_files_Solaris(){ #Production
 get_cron_GNU(){ #Production
 
 	# If archive is empty there were no files in var/spool/cron/crontabs directory
-	tar -czvf $OUTPUT/catscale_out/Persistence/$OUTFILE-cron-folder.tar.gz /var/spool/cron > $OUTPUT/catscale_out/Persistence/$OUTFILE-cron-folder-list.txt
+	tar -czvf $OUTPUT/$OUTDIR/Persistence/$OUTFILE-cron-folder.tar.gz /var/spool/cron > $OUTPUT/$OUTDIR/Persistence/$OUTFILE-cron-folder-list.txt
 	
 	for user in $(grep -v "/nologin\|/sync\|/false" /etc/passwd | cut -f1 -d ':'); 
 	do 
 		echo $user 
 		crontab -u $user -l 
 		echo "ENDOFUSERCRON"
-	done &> $OUTPUT/catscale_out/Persistence/$OUTFILE-cron-tab-list.txt
+	done &> $OUTPUT/$OUTDIR/Persistence/$OUTFILE-cron-tab-list.txt
 
 }
 get_cron_Solaris(){ #Production
 
 	# If archive is empty there were no files in var/spool/cron/crontabs directory
-	tar -czvf $OUTPUT/catscale_out/Persistence/$OUTFILE-cron-folder.tar.gz /var/spool/cron > $OUTPUT/catscale_out/Persistence/$OUTFILE-cron-folder-list.txt
+	tar -czvf $OUTPUT/$OUTDIR/Persistence/$OUTFILE-cron-folder.tar.gz /var/spool/cron > $OUTPUT/$OUTDIR/Persistence/$OUTFILE-cron-folder-list.txt
 	
 	for user in $(grep "/bash" /etc/passwd | cut -f1 -d ':'); 
 	do 
 		echo $user
 		crontab -l $user 2>/dev/null
-	done &> $OUTPUT/catscale_out/Persistence/$OUTFILE-cron-tab-list.txt
+	done &> $OUTPUT/$OUTDIR/Persistence/$OUTFILE-cron-tab-list.txt
 
 }
 
@@ -619,7 +621,7 @@ get_cron_Solaris(){ #Production
 #
 get_executables(){ #Production
 
-    find / -type f -perm -o+rx -print0 | xargs -0 sha1sum > $OUTPUT/catscale_out/Misc/$OUTFILE-exec-perm-files.txt
+    find / -type f -perm -o+rx -print0 | xargs -0 sha1sum > $OUTPUT/$OUTDIR/Misc/$OUTFILE-exec-perm-files.txt
 
 }
 
@@ -629,12 +631,12 @@ get_executables(){ #Production
 get_suspicios_data(){ #Production
 
 	#Find files in dev dir directory. Not common. Might be empty if none found
-	find /dev/ -type f -print0 | xargs -0 file 2>/dev/null > $OUTPUT/catscale_out/Misc/$OUTFILE-dev-dir-files.txt
+	find /dev/ -type f -print0 | xargs -0 file 2>/dev/null > $OUTPUT/$OUTDIR/Misc/$OUTFILE-dev-dir-files.txt
 	#If no found there will be single entry with d41d8cd98f00b204e9800998ecf8427e - 
-	find /dev/ -type f -print0 | xargs -0 sha1sum > $OUTPUT/catscale_out/Misc/$OUTFILE-dev-dir-files-hashes.txt
+	find /dev/ -type f -print0 | xargs -0 sha1sum > $OUTPUT/$OUTDIR/Misc/$OUTFILE-dev-dir-files-hashes.txt
 
 	#Find potential privilege escalation binaries/modifications (all Setuid Setguid binaries)
-	find / -xdev -type f \( -perm -04000 -o -perm -02000 \) > $OUTPUT/catscale_out/Misc/$OUTFILE-Setuid-Setguid-tools.txt
+	find / -xdev -type f \( -perm -04000 -o -perm -02000 \) > $OUTPUT/$OUTDIR/Misc/$OUTFILE-Setuid-Setguid-tools.txt
 }
 
 #
@@ -642,9 +644,9 @@ get_suspicios_data(){ #Production
 # 
 get_pot_webshell(){ #Production
     
-    find / -xdev -type f \( -iname '*.jsp' -o -iname '*.asp' -o -iname '*.php' -o -iname '*.aspx' \) 2>/dev/null -print0 | xargs -0 sha1sum > $OUTPUT/catscale_out/Misc/$OUTFILE-pot-webshell-hashes.txt
+    find / -xdev -type f \( -iname '*.jsp' -o -iname '*.asp' -o -iname '*.php' -o -iname '*.aspx' \) 2>/dev/null -print0 | xargs -0 sha1sum > $OUTPUT/$OUTDIR/Misc/$OUTFILE-pot-webshell-hashes.txt
     
-    find / -xdev -type f \( -iname '*.jsp' -o -iname '*.asp' -o -iname '*.php' -o -iname '*.aspx' \) 2>/dev/null -print0 | xargs -0 head -1000 > $OUTPUT/catscale_out/Misc/$OUTFILE-pot-webshell-first-1000.txt
+    find / -xdev -type f \( -iname '*.jsp' -o -iname '*.asp' -o -iname '*.php' -o -iname '*.aspx' \) 2>/dev/null -print0 | xargs -0 head -1000 > $OUTPUT/$OUTDIR/Misc/$OUTFILE-pot-webshell-first-1000.txt
     
 }
 	
@@ -655,24 +657,24 @@ end_collection(){ #Production
 
 	# Archive/Compress files
 	echo " "
-	echo " Creating catscale_$OUTFILE.tar.gz "
-	tar -czf $OUTPUT/catscale_$OUTFILE.tar.gz $OUTPUT/catscale_out
+	echo " Creating $OUTFILE.tar.gz "
+	tar -czf $OUTPUT/$OUTFILE_PREFIX$OUTFILE.tar.gz $OUTPUT/$OUTDIR
 	
-	# Clean-up catscale_out directory if the tar exists
-	if [ -f $OUTPUT/catscale_$OUTFILE.tar.gz ]; then
+	# Clean-up $OUTDIR directory if the tar exists
+	if [ -f $OUTPUT/$OUTFILE_PREFIX$OUTFILE.tar.gz ]; then
 	 echo " "
 	 echo " Cleaning up!..."
-	 rm -r $OUTPUT/catscale_out
+	 rm -r $OUTPUT/$OUTDIR
 	fi
 	
 	# Check if clean-up has been successful
-	if [ ! -d $OUTPUT/catscale_out ]; then
+	if [ ! -d $OUTPUT/$OUTDIR ]; then
 	 echo " Clean-up Successful!"
 	fi
-	if [ -d $OUTPUT/catscale_out ]; then
+	if [ -d $OUTPUT/$OUTDIR ]; then
 	 echo " "
 	 echo " WARNING Clean-up has not been successful please manually remove;"
-	 echo $OUTPUT/catscale_out
+	 echo $OUTPUT/$OUTDIR
 	fi
 	
 	# SHA1 the tar
@@ -682,7 +684,7 @@ end_collection(){ #Production
 	 echo "  Please submit the following file and SHA1 hash for analysis."
 	 echo " *************************************************************"
 	 echo " "
-	sha1sum $OUTPUT/catscale_$OUTFILE.tar.gz 
+	sha1sum $OUTPUT/$OUTFILE_PREFIX$OUTFILE.tar.gz
 	 echo " "
 }
 
@@ -730,7 +732,7 @@ case $oscheck in
 			get_pot_webshell
 			
 			
-		} 2>> $OUTPUT/catscale_out/$OUTFILE-console-error-log.txt
+		} 2>> $OUTPUT/$OUTDIR/$OUTFILE-console-error-log.txt
 		;;
 	*"red hat"*|*rhel*|*fedora*|*centos*)
 		#Red Hat\Centos\Fedora
@@ -768,7 +770,7 @@ case $oscheck in
 			echo " - Hashing potential webshells..."
 			get_pot_webshell
 			
-		} 2>> $OUTPUT/catscale_out/$OUTFILE-console-error-log.txt
+		} 2>> $OUTPUT/$OUTDIR/$OUTFILE-console-error-log.txt
 		;;
 	*sunos*|*solaris*)
 		#SunOS/Solaris
@@ -806,7 +808,7 @@ case $oscheck in
 			echo " - Hashing potential webshells..."
 			get_pot_webshell
 			
-		} 2>> $OUTPUT/catscale_out/$OUTFILE-console-error-log.txt
+		} 2>> $OUTPUT/$OUTDIR/$OUTFILE-console-error-log.txt
 		;;
 	*)
 		#Incompatible Distribution
@@ -843,7 +845,7 @@ case $oscheck in
 			echo " - Hashing potential webshells..."
 			get_pot_webshell
 			
-		} 2>> $OUTPUT/catscale_out/$OUTFILE-console-error-log.txt
+		} 2>> $OUTPUT/$OUTDIR/$OUTFILE-console-error-log.txt
         ;;
 		
 esac

--- a/Cat-Scale.sh
+++ b/Cat-Scale.sh
@@ -25,6 +25,46 @@
 ######################################################################################################
 ############################################ Global Variables ########################################
 ######################################################################################################
+# Check to see if options were passed in via CLI
+function usage {
+cat << EOF
+
+Usage: $0 [-d OUTDIR ] [-f OUTFILE ] [ -o OUTROOT ] [-p OUTFILE_PREFIX ]
+
+OUTROOT - Root directory/filesystem for output to be staged (Ex. /tmp)
+OUTDIR - Directory where output will be staged while running CatScale (Ex. catscale)
+OUTFILE_PREFIX - Prefix to use for tarfile (Ex. cs_)
+OUTFILE - Name of resultant tarfile created by catscale (.gz will be appended by the script) (Ex. mytarfile)
+
+
+EOF
+}
+
+while getopts "d:f:o:p:h" OPTION
+do
+    case $OPTION in
+        h)
+            usage
+            exit 0
+            ;;
+        d)
+            OUTDIR=$OPTARG
+            ;;
+        f)
+            OUTFILE=$OPTARG
+            ;;
+        o)
+            OUTROOT=$OPTARG
+            ;;
+        p)
+            OUTFILE_PREFIX=$OPTARG
+            ;;
+        *)
+            usage
+            exit 0
+            ;;
+    esac
+done
 
 # Force hostname format
 if hostname -s &>/dev/null; then
@@ -35,16 +75,19 @@ fi
 
 # Force date format
 DTG=$(date +"%Y%m%d-%H%M")
-# Outfile name
+# Outfile prefix
 OUTFILE_PREFIX=${OUTFILE_PREFIX:-catscale_}
+# Outfile name
 OUTFILE=${OUTFILE:-$SHORTNAME-$DTG}
+# Root dir/filesystem
+OUTROOT=${OUTROOT:-.}
+# Output directory
 OUTDIR=${OUTDIR:-catscale_out}
 
 #Define Global Variables
 oscheck=$(find /etc ! -path /etc -prune -name "*release*" -print0 | xargs -0 cat 2>/dev/null | tr [:upper:] [:lower:])
 osid=''
 uname=''
-OUTPUT=${OUTPUT:-.}
 
 ######################################################################################################
 ########################################### FUNCTIONS ################################################
@@ -86,7 +129,7 @@ starttheshow(){ #Production
 	echo " **********************************************************************************************"
     
 	# Exit if $OUTDIR folder exists.
-	if [ -d $OUTPUT/$OUTDIR ]; then
+	if [ -d $OUTROOT/$OUTDIR ]; then
 	 echo " "
 	 echo " ******************************************************"
 	 echo "  ERROR: Output path directory($OUTDIR) already exists! "
@@ -96,25 +139,25 @@ starttheshow(){ #Production
 	fi
 
 	# Create output directory if does not exist and chmod it
-	mkdir $OUTPUT/$OUTDIR
-	chmod 600 $OUTPUT/$OUTDIR
-	mkdir $OUTPUT/$OUTDIR/Process_and_Network
-	mkdir $OUTPUT/$OUTDIR/Logs
-	mkdir $OUTPUT/$OUTDIR/System_Info
-	mkdir $OUTPUT/$OUTDIR/Persistence
-	mkdir $OUTPUT/$OUTDIR/User_Files
-	mkdir $OUTPUT/$OUTDIR/Misc
-	mkdir $OUTPUT/$OUTDIR/Docker
-	mkdir $OUTPUT/$OUTDIR/Podman
-	mkdir $OUTPUT/$OUTDIR/Virsh
+	mkdir $OUTROOT/$OUTDIR
+	chmod 600 $OUTROOT/$OUTDIR
+	mkdir $OUTROOT/$OUTDIR/Process_and_Network
+	mkdir $OUTROOT/$OUTDIR/Logs
+	mkdir $OUTROOT/$OUTDIR/System_Info
+	mkdir $OUTROOT/$OUTDIR/Persistence
+	mkdir $OUTROOT/$OUTDIR/User_Files
+	mkdir $OUTROOT/$OUTDIR/Misc
+	mkdir $OUTROOT/$OUTDIR/Docker
+	mkdir $OUTROOT/$OUTDIR/Podman
+	mkdir $OUTROOT/$OUTDIR/Virsh
 	# Print OS info into error log
 	echo " "
 	echo "Running Collection Scripts "
 	echo " "
-	echo oscheck: $oscheck > $OUTPUT/$OUTDIR/$OUTFILE-console-error-log.txt
-	echo Date : $(date) >> $OUTPUT/$OUTDIR/$OUTFILE-console-error-log.txt
-	echo "================================ Console Errors ================================" >> $OUTPUT/$OUTDIR/$OUTFILE-console-error-log.txt
-	echo Date : $(date) > $OUTPUT/$OUTDIR/System_Info/$OUTFILE-host-date-timezone.txt
+	echo oscheck: $oscheck > $OUTROOT/$OUTDIR/$OUTFILE-console-error-log.txt
+	echo Date : $(date) >> $OUTROOT/$OUTDIR/$OUTFILE-console-error-log.txt
+	echo "================================ Console Errors ================================" >> $OUTROOT/$OUTDIR/$OUTFILE-console-error-log.txt
+	echo Date : $(date) > $OUTROOT/$OUTDIR/System_Info/$OUTFILE-host-date-timezone.txt
  }
  
 #
@@ -123,7 +166,7 @@ starttheshow(){ #Production
 #
 get_hidden_home_files(){ #Production
 
- grep -v "/nologin\|/sync\|/false" /etc/passwd | cut -f6 -d ':' | xargs -I {} find {} ! -path {} -prune -type f -name .\* -print0 | xargs -0 tar -czvf $OUTPUT/$OUTDIR/User_Files/hidden-user-home-dir.tar.gz  > $OUTPUT/$OUTDIR/User_Files/hidden-user-home-dir-list.txt
+ grep -v "/nologin\|/sync\|/false" /etc/passwd | cut -f6 -d ':' | xargs -I {} find {} ! -path {} -prune -type f -name .\* -print0 | xargs -0 tar -czvf $OUTROOT/$OUTDIR/User_Files/hidden-user-home-dir.tar.gz  > $OUTROOT/$OUTDIR/User_Files/hidden-user-home-dir-list.txt
 
 }
 
@@ -136,7 +179,7 @@ get_find_timeline(){ #Production
 		echo "Inode,Hard link Count,Full Path,Last Access,Last Modification,Last Status Change,File Creation,User,Group,File Permissions,File Size(bytes)"
 		find / -xdev -print0 | xargs -0 stat --printf="%i,%h,%n,%x,%y,%z,%w,%U,%G,%A,%s\n" 2>/dev/null
 		find /dev/shm -print0 | xargs -0 stat --printf="%i,%h,%n,%x,%y,%z,%w,%U,%G,%A,%s\n" 2>/dev/null
-	}> $OUTPUT/$OUTDIR/Misc/$OUTFILE-full-timeline.csv
+	}> $OUTROOT/$OUTDIR/Misc/$OUTFILE-full-timeline.csv
 	
 }
 
@@ -148,47 +191,47 @@ get_procinfo_GNU(){ #Production
 	echo "      Collecting Active Process..."
 	PS_FORMAT=user,pid,ppid,vsz,rss,tname,stat,stime,time,args
 	if ps axwwSo $PS_FORMAT &> /dev/null; then
-		ps axwwSo $PS_FORMAT > $OUTPUT/$OUTDIR/Process_and_Network/$OUTFILE-processes-axwwSo.txt
+		ps axwwSo $PS_FORMAT > $OUTROOT/$OUTDIR/Process_and_Network/$OUTFILE-processes-axwwSo.txt
 	elif ps auxSww &> /dev/null; then
-		ps auxSww > $OUTPUT/$OUTDIR/Process_and_Network/$OUTFILE-processes-auxSww.txt
+		ps auxSww > $OUTROOT/$OUTDIR/Process_and_Network/$OUTFILE-processes-auxSww.txt
 	elif ps auxww &> /dev/null; then
-		ps auxww > $OUTPUT/$OUTDIR/Process_and_Network/$OUTFILE-processes-auxww.txt
+		ps auxww > $OUTROOT/$OUTDIR/Process_and_Network/$OUTFILE-processes-auxww.txt
 	elif ps -eF &> /dev/null; then
-		ps -eF > $OUTPUT/$OUTDIR/Process_and_Network/$OUTFILE-processes-eF.txt
+		ps -eF > $OUTROOT/$OUTDIR/Process_and_Network/$OUTFILE-processes-eF.txt
 	elif ps -ef &> /dev/null; then
-		ps -ef > $OUTPUT/$OUTDIR/Process_and_Network/$OUTFILE-processes-ef.txt
+		ps -ef > $OUTROOT/$OUTDIR/Process_and_Network/$OUTFILE-processes-ef.txt
 	else
-		ps -e > $OUTPUT/$OUTDIR/Process_and_Network/$OUTFILE-processes-e.txt
+		ps -e > $OUTROOT/$OUTDIR/Process_and_Network/$OUTFILE-processes-e.txt
 	fi
 	
 
 	echo "      Getting the proc/*/status..."
-	find /proc -maxdepth 2 -wholename '/proc/[0-9]*/status' | xargs cat  >> $OUTPUT/$OUTDIR/Process_and_Network/$OUTFILE-process-details.txt
+	find /proc -maxdepth 2 -wholename '/proc/[0-9]*/status' | xargs cat  >> $OUTROOT/$OUTDIR/Process_and_Network/$OUTFILE-process-details.txt
 
 	echo "      Getting the process hashes..."
-	find -L /proc/[0-9]*/exe -print0 2>/dev/null | xargs -0 sha1sum 2>/dev/null > $OUTPUT/$OUTDIR/Process_and_Network/$OUTFILE-processhashes.txt
+	find -L /proc/[0-9]*/exe -print0 2>/dev/null | xargs -0 sha1sum 2>/dev/null > $OUTROOT/$OUTDIR/Process_and_Network/$OUTFILE-processhashes.txt
 	
 	echo "      Getting the process symbolic links..."
-	find /proc/[0-9]*/exe -print0 2>/dev/null | xargs -0 ls -lh 2>/dev/null > $OUTPUT/$OUTDIR/Process_and_Network/$OUTFILE-process-exe-links.txt
+	find /proc/[0-9]*/exe -print0 2>/dev/null | xargs -0 ls -lh 2>/dev/null > $OUTROOT/$OUTDIR/Process_and_Network/$OUTFILE-process-exe-links.txt
     
     echo "      Getting the process map_files hashes..."
-	find -L /proc/[0-9]*/map_files -type f -print0 2>/dev/null | xargs -0 sha1sum 2>/dev/null > $OUTPUT/$OUTDIR/Process_and_Network/$OUTFILE-process-map_files-link-hashes.txt
+	find -L /proc/[0-9]*/map_files -type f -print0 2>/dev/null | xargs -0 sha1sum 2>/dev/null > $OUTROOT/$OUTDIR/Process_and_Network/$OUTFILE-process-map_files-link-hashes.txt
     
     echo "      Getting the process map_files links..."
-	find /proc/[0-9]*/map_files -print0 2>/dev/null | xargs -0 ls -lh 2>/dev/null > $OUTPUT/$OUTDIR/Process_and_Network/$OUTFILE-process-map_files-links.txt
+	find /proc/[0-9]*/map_files -print0 2>/dev/null | xargs -0 ls -lh 2>/dev/null > $OUTROOT/$OUTDIR/Process_and_Network/$OUTFILE-process-map_files-links.txt
     
 	echo "      Getting the process fd links..."
-	find /proc/[0-9]*/fd -print0 2>/dev/null | xargs -0 ls -lh 2>/dev/null > $OUTPUT/$OUTDIR/Process_and_Network/$OUTFILE-process-fd-links.txt
+	find /proc/[0-9]*/fd -print0 2>/dev/null | xargs -0 ls -lh 2>/dev/null > $OUTROOT/$OUTDIR/Process_and_Network/$OUTFILE-process-fd-links.txt
 	
 	echo "      Getting the process cmdline..."
-	find /proc/[0-9]*/cmdline | xargs head 2>/dev/null > $OUTPUT/$OUTDIR/Process_and_Network/$OUTFILE-process-cmdline.txt
+	find /proc/[0-9]*/cmdline | xargs head 2>/dev/null > $OUTROOT/$OUTDIR/Process_and_Network/$OUTFILE-process-cmdline.txt
 
 	echo "      Getting the process environment variables..."
-	find /proc/[0-9]*/environ | xargs head 2>/dev/null > $OUTPUT/$OUTDIR/Process_and_Network/$OUTFILE-process-environment.txt
+	find /proc/[0-9]*/environ | xargs head 2>/dev/null > $OUTROOT/$OUTDIR/Process_and_Network/$OUTFILE-process-environment.txt
 
 	if which lsof &>/dev/null; then
 
-		lsof +c0 -M -R -V -w -n -P -e /run/user/1000/gvfs > $OUTPUT/$OUTDIR/Process_and_Network/$OUTFILE-lsof-list-open-files.txt
+		lsof +c0 -M -R -V -w -n -P -e /run/user/1000/gvfs > $OUTROOT/$OUTDIR/Process_and_Network/$OUTFILE-lsof-list-open-files.txt
 
   fi
 
@@ -199,19 +242,19 @@ get_procinfo_Solaris(){ #Production
 	#if output=$(ps -ef 2>/dev/null); then printf "%s\n" "$output" ; else echo no; fi
 	echo "      Collecting Active Process ..."
 	if ps -ef &> /dev/null; then
-		ps -ef > $OUTPUT/$OUTDIR/Process_and_Network/$OUTFILE-processes-ef.txt
+		ps -ef > $OUTROOT/$OUTDIR/Process_and_Network/$OUTFILE-processes-ef.txt
 	else
-		ps -e > $OUTPUT/$OUTDIR/Process_and_Network/$OUTFILE-processes-e.txt
+		ps -e > $OUTROOT/$OUTDIR/Process_and_Network/$OUTFILE-processes-e.txt
 	fi
 	
 	echo "      Getting the process hashes..."
-	find /proc/[0-9]*/object -name a.out | xargs sha1sum 2>/dev/null > $OUTPUT/$OUTDIR/Process_and_Network/$OUTFILE-processhashes.txt
+	find /proc/[0-9]*/object -name a.out | xargs sha1sum 2>/dev/null > $OUTROOT/$OUTDIR/Process_and_Network/$OUTFILE-processhashes.txt
 	
 	echo "      Getting the process cmdline..."
-	find /proc/[0-9]*/cmdline | xargs head 2>/dev/null > $OUTPUT/$OUTDIR/Process_and_Network/$OUTFILE-process-cmdline.txt
+	find /proc/[0-9]*/cmdline | xargs head 2>/dev/null > $OUTROOT/$OUTDIR/Process_and_Network/$OUTFILE-process-cmdline.txt
 	
 	if which lsof &>/dev/null; then
-		lsof -n -P -e /run/user/1000/gvfs > $OUTPUT/$OUTDIR/Process_and_Network/$OUTFILE-lsof-list-open-files.txt
+		lsof -n -P -e /run/user/1000/gvfs > $OUTROOT/$OUTDIR/Process_and_Network/$OUTFILE-lsof-list-open-files.txt
 	fi
 }
 
@@ -225,51 +268,51 @@ get_netinfo_GNU(){ #Production
 	#Get all network connections
 	echo "      Collecting Active Network Connections..."
 	if ss -anepo &>/dev/null; then
-		ss -anepo > $OUTPUT/$OUTDIR/Process_and_Network/$OUTFILE-ss-anepo.txt
+		ss -anepo > $OUTROOT/$OUTDIR/Process_and_Network/$OUTFILE-ss-anepo.txt
 
 	elif netstat -pvWanoee &>/dev/null; then
-		netstat -pvWanoee > $OUTPUT/$OUTDIR/Process_and_Network/$OUTFILE-netstat-pvWanoee.txt
+		netstat -pvWanoee > $OUTROOT/$OUTDIR/Process_and_Network/$OUTFILE-netstat-pvWanoee.txt
 
 	elif netstat -pvTanoee &>/dev/null; then
-		netstat -pvTanoee > $OUTPUT/$OUTDIR/Process_and_Network/$OUTFILE-netstat-pvTanoee.txt
+		netstat -pvTanoee > $OUTROOT/$OUTDIR/Process_and_Network/$OUTFILE-netstat-pvTanoee.txt
 
 	else
-		netstat -antup > $OUTPUT/$OUTDIR/Process_and_Network/$OUTFILE-netstat-antup.txt
-		netstat -an > $OUTPUT/$OUTDIR/Process_and_Network/$OUTFILE-netstat-an.txt
+		netstat -antup > $OUTROOT/$OUTDIR/Process_and_Network/$OUTFILE-netstat-antup.txt
+		netstat -an > $OUTROOT/$OUTDIR/Process_and_Network/$OUTFILE-netstat-an.txt
 
 	fi
 	
 	#Get ip and interface config
 	echo "      Collecting IP and Interface Config..."
 	if which ip &>/dev/null; then
-		ip a > $OUTPUT/$OUTDIR/Process_and_Network/$OUTFILE-ip-a.txt
+		ip a > $OUTROOT/$OUTDIR/Process_and_Network/$OUTFILE-ip-a.txt
 	else 
-		ifconfig -a > $OUTPUT/$OUTDIR/Process_and_Network/$OUTFILE-ifconfig.txt
+		ifconfig -a > $OUTROOT/$OUTDIR/Process_and_Network/$OUTFILE-ifconfig.txt
 	fi
 	
 	#Get routing table
 	echo "      Collecting Routing Table..."
 	if ip route &>/dev/null; then
-		ip route > $OUTPUT/$OUTDIR/Process_and_Network/$OUTFILE-routetable.txt
+		ip route > $OUTROOT/$OUTDIR/Process_and_Network/$OUTFILE-routetable.txt
 	else
-		netstat -rn > $OUTPUT/$OUTDIR/Process_and_Network/$OUTFILE-routetable.txt
+		netstat -rn > $OUTROOT/$OUTDIR/Process_and_Network/$OUTFILE-routetable.txt
 	fi
 	
 	#Get iptables. Firewall rules.
 	echo "      Collecting IPtables..."
 
-	iptables -L -n -v --line-numbers > $OUTPUT/$OUTDIR/Process_and_Network/$OUTFILE-iptables-numerical.txt
+	iptables -L -n -v --line-numbers > $OUTROOT/$OUTDIR/Process_and_Network/$OUTFILE-iptables-numerical.txt
   
-	iptables -L > $OUTPUT/$OUTDIR/Process_and_Network/$OUTFILE-iptables.txt
+	iptables -L > $OUTROOT/$OUTDIR/Process_and_Network/$OUTFILE-iptables.txt
 
 	
 
 	#Get SeLinux Verbose information
 	if which sestatus &>/dev/null; then
 		echo "      Collecting SELinux status..."
-		sestatus -v > $OUTPUT/$OUTDIR/Process_and_Network/$OUTFILE-selinux.txt
+		sestatus -v > $OUTROOT/$OUTDIR/Process_and_Network/$OUTFILE-selinux.txt
 		echo "      Collecting SELinux booleans..."
-		getsebool -a > $OUTPUT/$OUTDIR/Process_and_Network/$OUTFILE-getsebool.txt
+		getsebool -a > $OUTROOT/$OUTDIR/Process_and_Network/$OUTFILE-getsebool.txt
 	fi
 	
 	
@@ -278,28 +321,28 @@ get_netinfo_Solaris(){ #Production
 	
 	#Get network connections
 	echo "      Collecting Active Network Connections..."
-	netstat -an > $OUTPUT/$OUTDIR/Process_and_Network/$OUTFILE-netstat-an.txt
+	netstat -an > $OUTROOT/$OUTDIR/Process_and_Network/$OUTFILE-netstat-an.txt
 
 	#Get ip and interface config
 	echo "      Collecting IP and Interface Config..."
-	ifconfig -a > $OUTPUT/$OUTDIR/Process_and_Network/$OUTFILE-ifconfig.txt
+	ifconfig -a > $OUTROOT/$OUTDIR/Process_and_Network/$OUTFILE-ifconfig.txt
 	
 	#Get ipf table. Firewall rules. Might need further testing and optimization 
 	if which ipfstat &>/dev/null; then
 		echo "      Collecting ipf tables..."
-		ipfstat -ion > $OUTPUT/$OUTDIR/Process_and_Network/$OUTFILE-ipftables.txt
+		ipfstat -ion > $OUTROOT/$OUTDIR/Process_and_Network/$OUTFILE-ipftables.txt
 	fi
 
 	#Get routing table
 	echo "      Collecting Routing Table..."
-	netstat -rn > $OUTPUT/$OUTDIR/Process_and_Network/$OUTFILE-routetable.txt
+	netstat -rn > $OUTROOT/$OUTDIR/Process_and_Network/$OUTFILE-routetable.txt
 	
 	#Get SeLinux Verbose information
 	if which sestatus &>/dev/null; then
 		echo "      Collecting SELinux status..."
-		sestatus -v > $OUTPUT/$OUTDIR/Process_and_Network/$OUTFILE-selinux.txt
+		sestatus -v > $OUTROOT/$OUTDIR/Process_and_Network/$OUTFILE-selinux.txt
 		echo "      Collecting SELinux booleans..."
-		getsebool -a > $OUTPUT/$OUTDIR/Process_and_Network/$OUTFILE-getsebool.txt
+		getsebool -a > $OUTROOT/$OUTDIR/Process_and_Network/$OUTFILE-getsebool.txt
 	fi
 
 }
@@ -314,10 +357,10 @@ get_config_GNU(){ #Production
 	files="( -iname yum* -o -iname apt* -o -iname hosts* -o -iname passwd \
 	-o -iname sudoers* -o -iname cron* -o -iname ssh* -o -iname rc* -o -iname systemd* -o -iname anacron  \
 	-o -iname inittab -o -iname init.d -o -iname profile* -o -iname bash* )"
-    find /etc/ -type f,d $files -print0 | xargs -0 tar -czvf $OUTPUT/$OUTDIR/System_Info/$OUTFILE-etc-key-files.tar.gz 2>/dev/null > $OUTPUT/$OUTDIR/System_Info/$OUTFILE-etc-key-files-list.txt
+    find /etc/ -type f,d $files -print0 | xargs -0 tar -czvf $OUTROOT/$OUTDIR/System_Info/$OUTFILE-etc-key-files.tar.gz 2>/dev/null > $OUTROOT/$OUTDIR/System_Info/$OUTFILE-etc-key-files-list.txt
     
     # Get files that were modified in the last 90 days, collect all files, including symbolic links
-    find /etc/ -type f -mtime -90 -print0 | xargs -0 tar -czvf $OUTPUT/$OUTDIR/System_Info/$OUTFILE-etc-modified-files.tar.gz --dereference --hard-dereference 2>/dev/null > $OUTPUT/$OUTDIR/System_Info/$OUTFILE-etc-modified-files-list.txt
+    find /etc/ -type f -mtime -90 -print0 | xargs -0 tar -czvf $OUTROOT/$OUTDIR/System_Info/$OUTFILE-etc-modified-files.tar.gz --dereference --hard-dereference 2>/dev/null > $OUTROOT/$OUTDIR/System_Info/$OUTFILE-etc-modified-files-list.txt
 	
 }
 
@@ -327,10 +370,10 @@ get_config_Solaris(){ #Production
 	files="( ( -iname yum* -o -iname apt* -o -iname hosts* -o -iname passwd \
 	-o -iname sudoers* -o -iname cron* -o -iname ssh* -o -iname rc* -o -iname systemd* -o -iname anacron  \
 	-o -iname inittab -o -iname init.d -o -iname profile* -o -iname bash* ) -a ( -type f -o -type d ) )"
-	find /etc/ $files -print0 | xargs -0 tar -czvf $OUTPUT/$OUTDIR/System_Info/$OUTFILE-etc-key-files.tar.gz 2>/dev/null > $OUTPUT/$OUTDIR/System_Info/$OUTFILE-etc-key-files-list.txt
+	find /etc/ $files -print0 | xargs -0 tar -czvf $OUTROOT/$OUTDIR/System_Info/$OUTFILE-etc-key-files.tar.gz 2>/dev/null > $OUTROOT/$OUTDIR/System_Info/$OUTFILE-etc-key-files-list.txt
     
     # Get files that were modified in the last 90 days, collect all files, including symbolic links
-    find /etc/ -mtime -90 -print0 | xargs -0 tar -czvf $OUTPUT/$OUTDIR/System_Info/$OUTFILE-etc-modified-files.tar.gz 2>/dev/null > $OUTPUT/$OUTDIR/System_Info/$OUTFILE-etc-modified-files-list.txt
+    find /etc/ -mtime -90 -print0 | xargs -0 tar -czvf $OUTROOT/$OUTDIR/System_Info/$OUTFILE-etc-modified-files.tar.gz 2>/dev/null > $OUTROOT/$OUTDIR/System_Info/$OUTFILE-etc-modified-files-list.txt
 	
 }
 
@@ -340,61 +383,61 @@ get_config_Solaris(){ #Production
 get_logs_GNU(){ #Production
 
 	echo "      Collecting logged in users..."
-	who -a > $OUTPUT/$OUTDIR/Logs/$OUTFILE-who.txt
+	who -a > $OUTROOT/$OUTDIR/Logs/$OUTFILE-who.txt
 	
 	echo "      Collecting 'w'..."
-	w > $OUTPUT/$OUTDIR/Logs/$OUTFILE-whoandwhat.txt
+	w > $OUTROOT/$OUTDIR/Logs/$OUTFILE-whoandwhat.txt
 
 	echo "      Collecting bad logins(btmp)..."
-	find /var/log -maxdepth 1 -type f -name "btmp*" -exec last -Faiwx -f {} \; > $OUTPUT/$OUTDIR/Logs/$OUTFILE-last-btmp.txt
+	find /var/log -maxdepth 1 -type f -name "btmp*" -exec last -Faiwx -f {} \; > $OUTROOT/$OUTDIR/Logs/$OUTFILE-last-btmp.txt
 	
 	echo "      Collecting Active Logon information(utmp)..."
-	find / -maxdepth 2 -type f -name "utmp*" -exec last -Faiwx -f {} \; > $OUTPUT/$OUTDIR/Logs/$OUTFILE-last-utmp.txt
-	find / -maxdepth 2 -type f -name "utmp*" -exec utmpdump {} \; > $OUTPUT/$OUTDIR/Logs/$OUTFILE-last-utmpdump.txt
+	find / -maxdepth 2 -type f -name "utmp*" -exec last -Faiwx -f {} \; > $OUTROOT/$OUTDIR/Logs/$OUTFILE-last-utmp.txt
+	find / -maxdepth 2 -type f -name "utmp*" -exec utmpdump {} \; > $OUTROOT/$OUTDIR/Logs/$OUTFILE-last-utmpdump.txt
 	
 	echo "      Collecting Historic Logon information(wtmp)..."
-	find /var/log -maxdepth 1 -type f -name "wtmp*" -exec last -Faiwx -f {} \; > $OUTPUT/$OUTDIR/Logs/$OUTFILE-last-wtmp.txt
+	find /var/log -maxdepth 1 -type f -name "wtmp*" -exec last -Faiwx -f {} \; > $OUTROOT/$OUTDIR/Logs/$OUTFILE-last-wtmp.txt
 	
 	echo "      Collecting lastlog..."
-	lastlog > $OUTPUT/$OUTDIR/Logs/$OUTFILE-lastlog.txt
+	lastlog > $OUTROOT/$OUTDIR/Logs/$OUTFILE-lastlog.txt
 
 	echo "      Checking passwd integrity"
-	pwck -r > $OUTPUT/$OUTDIR/Logs/$OUTFILE-passwd-check.txt
+	pwck -r > $OUTROOT/$OUTDIR/Logs/$OUTFILE-passwd-check.txt
 
 	#Collect all files in in /var/log folder.
 	echo "      Collecting /var/log/ folder..."
-	tar -czvf $OUTPUT/$OUTDIR/Logs/$OUTFILE-var-log.tar.gz --dereference --hard-dereference --sparse /var/log > $OUTPUT/$OUTDIR/Logs/$OUTFILE-var-log-list.txt
+	tar -czvf $OUTROOT/$OUTDIR/Logs/$OUTFILE-var-log.tar.gz --dereference --hard-dereference --sparse /var/log > $OUTROOT/$OUTDIR/Logs/$OUTFILE-var-log-list.txt
 
 	#Collect all files in in /var/crash folder.
 	echo "      Collecting /var/crash/ folder..."
-    tar -czvf $OUTPUT/$OUTDIR/Logs/$OUTFILE-var-crash.tar.gz --dereference --hard-dereference --sparse /var/crash > $OUTPUT/$OUTDIR/Logs/$OUTFILE-var-crash-list.txt
+    tar -czvf $OUTROOT/$OUTDIR/Logs/$OUTFILE-var-crash.tar.gz --dereference --hard-dereference --sparse /var/crash > $OUTROOT/$OUTDIR/Logs/$OUTFILE-var-crash-list.txt
 	
 }
 get_logs_Solaris(){ #Production
 
 	echo "      Collecting logged in users..."
-	who -a > $OUTPUT/$OUTDIR/Logs/$OUTFILE-who.txt
+	who -a > $OUTROOT/$OUTDIR/Logs/$OUTFILE-who.txt
 	
 	echo "      Collecting 'w'..."
-	w > $OUTPUT/$OUTDIR/Logs/$OUTFILE-whoandwhat.txt
+	w > $OUTROOT/$OUTDIR/Logs/$OUTFILE-whoandwhat.txt
 
 	echo "      Collecting bad logins(btmp)..."
-	find /var/adm -type f -name "btmp*" -exec last -f {} \; > $OUTPUT/$OUTDIR/Logs/$OUTFILE-last-btmpx.txt
+	find /var/adm -type f -name "btmp*" -exec last -f {} \; > $OUTROOT/$OUTDIR/Logs/$OUTFILE-last-btmpx.txt
 	
 	echo "      Collecting Historic Logon information(wtmp)..."
-	find /var/adm -type f -name "wtmp*" -exec last -f {} \; > $OUTPUT/$OUTDIR/Logs/$OUTFILE-last-wtmpx.txt
+	find /var/adm -type f -name "wtmp*" -exec last -f {} \; > $OUTROOT/$OUTDIR/Logs/$OUTFILE-last-wtmpx.txt
 
 	#Collect all files in in /var/log folder.
 	echo "      Collecting /var/log/ folder..."
-	find /var/log -type f -print0 | xargs -0 tar -czfv $OUTPUT/$OUTDIR/Logs/$OUTFILE-var-log.tar.gz > $OUTPUT/$OUTDIR/Logs/$OUTFILE-var-log-list.txt
+	find /var/log -type f -print0 | xargs -0 tar -czfv $OUTROOT/$OUTDIR/Logs/$OUTFILE-var-log.tar.gz > $OUTROOT/$OUTDIR/Logs/$OUTFILE-var-log-list.txt
 	
 	#Collect all files in in /var/adm folder.
 	echo "      Collecting /var/adm/ folder..."
-	find /var/adm -type f -print0 | xargs -0 tar -czfv $OUTPUT/$OUTDIR/Logs/$OUTFILE-var-adm.tar.gz  > $OUTPUT/$OUTDIR/Logs/$OUTFILE-var-adm-list.txt
+	find /var/adm -type f -print0 | xargs -0 tar -czfv $OUTROOT/$OUTDIR/Logs/$OUTFILE-var-adm.tar.gz  > $OUTROOT/$OUTDIR/Logs/$OUTFILE-var-adm-list.txt
 
 	#Collect all files in in /var/crash folder.
 	echo "      Collecting /var/crash/ folder..."
-	find /var/crash -type f -print0 | xargs -0 tar -czfv $OUTPUT/$OUTDIR/Logs/$OUTFILE-var-crash.tar.gz  > $OUTPUT/$OUTDIR/Logs/$OUTFILE-var-crash-list.txt
+	find /var/crash -type f -print0 | xargs -0 tar -czfv $OUTROOT/$OUTDIR/Logs/$OUTFILE-var-crash.tar.gz  > $OUTROOT/$OUTDIR/Logs/$OUTFILE-var-crash-list.txt
 
 }
 
@@ -405,7 +448,7 @@ get_logs_Solaris(){ #Production
 get_sshkeynhosts(){ #Production
 	
 	echo "      Collecting .ssh folder..."
-	find / -xdev -type d -name .ssh -print0 | xargs -0 tar -czvf $OUTPUT/$OUTDIR/Process_and_Network/$OUTFILE-ssh-folders.tar.gz > $OUTPUT/$OUTDIR/Process_and_Network/$OUTFILE-ssh-folders-list.txt
+	find / -xdev -type d -name .ssh -print0 | xargs -0 tar -czvf $OUTROOT/$OUTDIR/Process_and_Network/$OUTFILE-ssh-folders.tar.gz > $OUTROOT/$OUTDIR/Process_and_Network/$OUTFILE-ssh-folders-list.txt
 
 }
 
@@ -416,67 +459,67 @@ get_sshkeynhosts(){ #Production
 get_systeminfo_GNU(){ #Production
 
 	echo "      Collecting Memory info..."
-	cat /proc/meminfo > $OUTPUT/$OUTDIR/System_Info/$OUTFILE-meminfo.txt
+	cat /proc/meminfo > $OUTROOT/$OUTDIR/System_Info/$OUTFILE-meminfo.txt
 	
 	echo "      Collecting CPU info..."
-	cat /proc/cpuinfo > $OUTPUT/$OUTDIR/System_Info/$OUTFILE-cpuinfo.txt
+	cat /proc/cpuinfo > $OUTROOT/$OUTDIR/System_Info/$OUTFILE-cpuinfo.txt
 	
 	echo "      Collecting df..."
-	df > $OUTPUT/$OUTDIR/System_Info/$OUTFILE-df.txt
+	df > $OUTROOT/$OUTDIR/System_Info/$OUTFILE-df.txt
 	
 	echo "      Collecting mount..."
-	mount > $OUTPUT/$OUTDIR/System_Info/$OUTFILE-mount.txt
+	mount > $OUTROOT/$OUTDIR/System_Info/$OUTFILE-mount.txt
 	
 	echo "      Collecting attached USB device info..."
-	lsusb -v > $OUTPUT/$OUTDIR/System_Info/$OUTFILE-lsusb.txt
+	lsusb -v > $OUTROOT/$OUTDIR/System_Info/$OUTFILE-lsusb.txt
 
 	echo "      Collecting kernel release..."	
-	find /etc ! -path /etc -prune -name "*release*" -print0 | xargs -0 cat 2>/dev/null > $OUTPUT/$OUTDIR/System_Info/$OUTFILE-release.txt
-	echo -n "KERNELVERSION(uname -r)=" >> $OUTPUT/$OUTDIR/System_Info/$OUTFILE-release.txt
-	uname -r >> $OUTPUT/$OUTDIR/System_Info/$OUTFILE-release.txt
+	find /etc ! -path /etc -prune -name "*release*" -print0 | xargs -0 cat 2>/dev/null > $OUTROOT/$OUTDIR/System_Info/$OUTFILE-release.txt
+	echo -n "KERNELVERSION(uname -r)=" >> $OUTROOT/$OUTDIR/System_Info/$OUTFILE-release.txt
+	uname -r >> $OUTROOT/$OUTDIR/System_Info/$OUTFILE-release.txt
 
 	echo "      Collecting lsmod..."
-	lsmod > $OUTPUT/$OUTDIR/System_Info/$OUTFILE-lsmod.txt
+	lsmod > $OUTROOT/$OUTDIR/System_Info/$OUTFILE-lsmod.txt
 	
 	echo "      Collecting modinfo..."
-	for i in `lsmod | awk '{print $1}' | sed '/Module/d'`; do echo -e "\nModule: $i"; modinfo $i ; done > $OUTPUT/$OUTDIR/System_Info/$OUTFILE-modinfo.txt
+	for i in `lsmod | awk '{print $1}' | sed '/Module/d'`; do echo -e "\nModule: $i"; modinfo $i ; done > $OUTROOT/$OUTDIR/System_Info/$OUTFILE-modinfo.txt
 
 	echo "      Collecting loaded modules..."
-	for i in `lsmod | awk '{print $1}' | sed '/Module/d'`; do modinfo $i | grep "filename:" | awk '{print $2}' | xargs -I{} sha1sum {} ; done > $OUTPUT/$OUTDIR/System_Info/$OUTFILE-module-sha1.txt
+	for i in `lsmod | awk '{print $1}' | sed '/Module/d'`; do modinfo $i | grep "filename:" | awk '{print $2}' | xargs -I{} sha1sum {} ; done > $OUTROOT/$OUTDIR/System_Info/$OUTFILE-module-sha1.txt
 	
 	echo "      Collecting proc/modules..."
-	cat '/proc/modules' > $OUTPUT/$OUTDIR/System_Info/$OUTFILE-procmod.txt
+	cat '/proc/modules' > $OUTROOT/$OUTDIR/System_Info/$OUTFILE-procmod.txt
 	
 	echo "      Collecting sudo config..."
-	sudo -V > $OUTPUT/$OUTDIR/System_Info/$OUTFILE-sudo.txt
+	sudo -V > $OUTROOT/$OUTDIR/System_Info/$OUTFILE-sudo.txt
 
 	echo "      Collecting dmesg..."
-	dmesg -T > $OUTPUT/$OUTDIR/System_Info/$OUTFILE-dmesg.txt
+	dmesg -T > $OUTROOT/$OUTDIR/System_Info/$OUTFILE-dmesg.txt
 
 
 }
 get_systeminfo_Solaris(){ #Production
 
 	echo "      Collecting Memory info..."
-	vmstat -p > $OUTPUT/$OUTDIR/System_Info/$OUTFILE-meminfo.txt
-	prstat -s size 1 1 > $OUTPUT/$OUTDIR/System_Info/$OUTFILE-ProcMemUsage.txt
-	ipcs -a > $OUTPUT/$OUTDIR/System_Info/$OUTFILE-SharedMemAndSemaphores.txt
+	vmstat -p > $OUTROOT/$OUTDIR/System_Info/$OUTFILE-meminfo.txt
+	prstat -s size 1 1 > $OUTROOT/$OUTDIR/System_Info/$OUTFILE-ProcMemUsage.txt
+	ipcs -a > $OUTROOT/$OUTDIR/System_Info/$OUTFILE-SharedMemAndSemaphores.txt
 		
 	echo "      Collecting CPU info..."
-	prtdiag -v > $OUTPUT/$OUTDIR/System_Info/$OUTFILE-cpuinfo.txt
-	psrinfo -v >> $OUTPUT/$OUTDIR/System_Info/$OUTFILE-cpuinfo.txt
+	prtdiag -v > $OUTROOT/$OUTDIR/System_Info/$OUTFILE-cpuinfo.txt
+	psrinfo -v >> $OUTROOT/$OUTDIR/System_Info/$OUTFILE-cpuinfo.txt
 	
 	echo "      Collecting df..."
-	df > $OUTPUT/$OUTDIR/System_Info/$OUTFILE-df.txt
+	df > $OUTROOT/$OUTDIR/System_Info/$OUTFILE-df.txt
 	
 	echo "      Collecting attached USB device info..."
-	rmformat > $OUTPUT/$OUTDIR/System_Info/$OUTFILE-removeblemedia.txt
+	rmformat > $OUTROOT/$OUTDIR/System_Info/$OUTFILE-removeblemedia.txt
 	
 	echo "      Collecting kernel release..."		
-	find /etc ! -path /etc -prune -name "*release*" -print0 | xargs -0 cat 2>/dev/null > $OUTPUT/$OUTDIR/System_Info/$OUTFILE-release.txt
+	find /etc ! -path /etc -prune -name "*release*" -print0 | xargs -0 cat 2>/dev/null > $OUTROOT/$OUTDIR/System_Info/$OUTFILE-release.txt
 
 	echo "      Collecting loaded modules..."
-	modinfo -ao namedesc,state,loadcnt,path > $OUTPUT/$OUTDIR/System_Info/$OUTFILE-modules.txt
+	modinfo -ao namedesc,state,loadcnt,path > $OUTROOT/$OUTDIR/System_Info/$OUTFILE-modules.txt
 	
 }
 
@@ -486,56 +529,56 @@ get_systeminfo_Solaris(){ #Production
 get_docker_info(){ #Testing
 	if which docker &>/dev/null; then
 		echo "      Collecting Docker info..."
-		docker container ls --all --size > $OUTPUT/$OUTDIR/Docker/$OUTFILE-docker-container-ls-all-size.txt
-		docker image ls --all > $OUTPUT/$OUTDIR/Docker/$OUTFILE-docker-image-ls-all.txt
-		docker info > $OUTPUT/$OUTDIR/Docker/$OUTFILE-docker-info.txt
+		docker container ls --all --size > $OUTROOT/$OUTDIR/Docker/$OUTFILE-docker-container-ls-all-size.txt
+		docker image ls --all > $OUTROOT/$OUTDIR/Docker/$OUTFILE-docker-image-ls-all.txt
+		docker info > $OUTROOT/$OUTDIR/Docker/$OUTFILE-docker-info.txt
 		docker container ps --all -q | while read line; do 
-			docker inspect $line > $OUTPUT/$OUTDIR/Docker/$OUTFILE-docker-inspect-$line.txt
-			docker container top $line > $OUTPUT/$OUTDIR/Docker/$OUTFILE-docker-top-$line.txt
-			docker container logs $line > $OUTPUT/$OUTDIR/Docker/$OUTFILE-docker-container-logs-$line.txt
-			docker container port $line > $OUTPUT/$OUTDIR/Docker/$OUTFILE-docker-container-port-$line.txt
-			docker container diff $line > $OUTPUT/$OUTDIR/Docker/$OUTFILE-docker-container-diff-$line.txt
+			docker inspect $line > $OUTROOT/$OUTDIR/Docker/$OUTFILE-docker-inspect-$line.txt
+			docker container top $line > $OUTROOT/$OUTDIR/Docker/$OUTFILE-docker-top-$line.txt
+			docker container logs $line > $OUTROOT/$OUTDIR/Docker/$OUTFILE-docker-container-logs-$line.txt
+			docker container port $line > $OUTROOT/$OUTDIR/Docker/$OUTFILE-docker-container-port-$line.txt
+			docker container diff $line > $OUTROOT/$OUTDIR/Docker/$OUTFILE-docker-container-diff-$line.txt
 		done 2>/dev/null
 		docker network ls | sed 1d | cut -d" " -f 1 | while read line; do 
-			docker network inspect $line > $OUTPUT/$OUTDIR/Docker/$OUTFILE-docker-network-inspect-$line.txt
+			docker network inspect $line > $OUTROOT/$OUTDIR/Docker/$OUTFILE-docker-network-inspect-$line.txt
 		done 2>/dev/null
-		docker version > $OUTPUT/$OUTDIR/Docker/$OUTFILE-docker-version.txt
+		docker version > $OUTROOT/$OUTDIR/Docker/$OUTFILE-docker-version.txt
 	fi
 	if which podman &>/dev/null; then
 		echo "      Collecting Podman info..."
-		podman container ls --all --size > $OUTPUT/$OUTDIR/Podman/$OUTFILE-podman-container-ls-all-size.txt
-		podman image ls --all > $OUTPUT/$OUTDIR/Podman/$OUTFILE-podman-image-ls-all.txt
-		podman info > $OUTPUT/$OUTDIR/Podman/$OUTFILE-podman-info.txt
+		podman container ls --all --size > $OUTROOT/$OUTDIR/Podman/$OUTFILE-podman-container-ls-all-size.txt
+		podman image ls --all > $OUTROOT/$OUTDIR/Podman/$OUTFILE-podman-image-ls-all.txt
+		podman info > $OUTROOT/$OUTDIR/Podman/$OUTFILE-podman-info.txt
 		podman container ps --all -q | while read line; do
-			podman inspect $line > $OUTPUT/$OUTDIR/Podman/$OUTFILE-podman-inspect-$line.txt
-			podman container top $line > $OUTPUT/$OUTDIR/Podman/$OUTFILE-podman-top-$line.txt
-			podman container logs $line > $OUTPUT/$OUTDIR/Podman/$OUTFILE-podman-container-logs-$line.txt
-			podman container port $line > $OUTPUT/$OUTDIR/Podman/$OUTFILE-podman-container-port-$line.txt
-			podman container diff $line > $OUTPUT/$OUTDIR/Podman/$OUTFILE-podman-container-diff-$line.txt
+			podman inspect $line > $OUTROOT/$OUTDIR/Podman/$OUTFILE-podman-inspect-$line.txt
+			podman container top $line > $OUTROOT/$OUTDIR/Podman/$OUTFILE-podman-top-$line.txt
+			podman container logs $line > $OUTROOT/$OUTDIR/Podman/$OUTFILE-podman-container-logs-$line.txt
+			podman container port $line > $OUTROOT/$OUTDIR/Podman/$OUTFILE-podman-container-port-$line.txt
+			podman container diff $line > $OUTROOT/$OUTDIR/Podman/$OUTFILE-podman-container-diff-$line.txt
 		done 2>/dev/null
 		podman network ls | sed 1d | cut -d" " -f 1 | while read line; do
-			podman network inspect $line > $OUTPUT/$OUTDIR/Podman/$OUTFILE-podman-network-inspect-$line.txt
+			podman network inspect $line > $OUTROOT/$OUTDIR/Podman/$OUTFILE-podman-network-inspect-$line.txt
 		done 2>/dev/null
-		podman version > $OUTPUT/$OUTDIR/Podman/$OUTFILE-podman-version.txt
+		podman version > $OUTROOT/$OUTDIR/Podman/$OUTFILE-podman-version.txt
 	fi
 	if which virsh &>/dev/null; then
 		echo "      Collecting Virsh info..."
-		virsh list --all > $OUTPUT/$OUTDIR/Virsh/$OUTFILE-virsh-list-all.txt
+		virsh list --all > $OUTROOT/$OUTDIR/Virsh/$OUTFILE-virsh-list-all.txt
 		virsh list --name | while read line; do 
-			virsh domifaddr $line > $OUTPUT/$OUTDIR/Virsh/$OUTFILE-virsh-domifaddr-$line.txt
-			virsh dominfo $line > $OUTPUT/$OUTDIR/Virsh/$OUTFILE-virsh-dominfo-$line.txt
-			virsh dommemstat $line > $OUTPUT/$OUTDIR/Virsh/$OUTFILE-virsh-dommemstat-$line.txt
-			virsh snapshot-list $line > $OUTPUT/$OUTDIR/Virsh/$OUTFILE-virsh-snapshot-list-$line.txt
-			virsh vcpuinfo $line > $OUTPUT/$OUTDIR/Virsh/$OUTFILE-virsh-vcpuinfo-$line.txt
+			virsh domifaddr $line > $OUTROOT/$OUTDIR/Virsh/$OUTFILE-virsh-domifaddr-$line.txt
+			virsh dominfo $line > $OUTROOT/$OUTDIR/Virsh/$OUTFILE-virsh-dominfo-$line.txt
+			virsh dommemstat $line > $OUTROOT/$OUTDIR/Virsh/$OUTFILE-virsh-dommemstat-$line.txt
+			virsh snapshot-list $line > $OUTROOT/$OUTDIR/Virsh/$OUTFILE-virsh-snapshot-list-$line.txt
+			virsh vcpuinfo $line > $OUTROOT/$OUTDIR/Virsh/$OUTFILE-virsh-vcpuinfo-$line.txt
 		done 2>/dev/null
-		virsh net-list --all > $OUTPUT/$OUTDIR/Virsh/$OUTFILE-virsh-net-list-all.txt
+		virsh net-list --all > $OUTROOT/$OUTDIR/Virsh/$OUTFILE-virsh-net-list-all.txt
 		virsh net-list --all --name | while read line; do 
-			virsh net-info $line > $OUTPUT/$OUTDIR/Virsh/$OUTFILE-virsh-net-info-$line.txt
-			virsh net-dhcp-leases $line > $OUTPUT/$OUTDIR/Virsh/$OUTFILE-virsh-net-dhcp-leases-$line.txt
+			virsh net-info $line > $OUTROOT/$OUTDIR/Virsh/$OUTFILE-virsh-net-info-$line.txt
+			virsh net-dhcp-leases $line > $OUTROOT/$OUTDIR/Virsh/$OUTFILE-virsh-net-dhcp-leases-$line.txt
 		done 2>/dev/null
-		virsh nodeinfo > $OUTPUT/$OUTDIR/Virsh/$OUTFILE-virsh-nodeinfo.txt
-		virsh pool-list --all > $OUTPUT/$OUTDIR/Virsh/$OUTFILE-virsh-pool-list-all.txt
-		virt-top -n 1 > $OUTPUT/$OUTDIR/Virsh/$OUTFILE-virt-top-n-1.txt
+		virsh nodeinfo > $OUTROOT/$OUTDIR/Virsh/$OUTFILE-virsh-nodeinfo.txt
+		virsh pool-list --all > $OUTROOT/$OUTDIR/Virsh/$OUTFILE-virsh-pool-list-all.txt
+		virt-top -n 1 > $OUTROOT/$OUTDIR/Virsh/$OUTFILE-virt-top-n-1.txt
 	fi
 }
 
@@ -546,16 +589,16 @@ get_packageinfo_GNU(){ #Production
 
 	echo "      Collecting installed package info..."
 	if which dpkg &>/dev/null; then
-		dpkg --list > $OUTPUT/$OUTDIR/System_Info/$OUTFILE-deb-packages.txt
+		dpkg --list > $OUTROOT/$OUTDIR/System_Info/$OUTFILE-deb-packages.txt
 	else 
-		rpm -qa > $OUTPUT/$OUTDIR/System_Info/$OUTFILE-rpm-packages.txt
+		rpm -qa > $OUTROOT/$OUTDIR/System_Info/$OUTFILE-rpm-packages.txt
 	fi
 	
 }
 get_packageinfo_Solaris(){ #Production
 
 	echo "      Collecting installed package info..."
-	pkginfo > $OUTPUT/$OUTDIR/System_Info/$OUTFILE-solaris-packages.txt
+	pkginfo > $OUTROOT/$OUTDIR/System_Info/$OUTFILE-solaris-packages.txt
 	
 }
 
@@ -565,21 +608,21 @@ get_packageinfo_Solaris(){ #Production
 get_startup_files_GNU(){ #Production
 
 	echo "      Collecting service status all..."
-	echo "This file might be empty as Latest versions of Red Hat, Fedora and Centos do not use service command. If this is empty please review systemctl file. " > $OUTPUT/$OUTDIR/Persistence/$OUTFILE-service_status.txt
-	service --status-all >> $OUTPUT/$OUTDIR/Persistence/$OUTFILE-service_status.txt
-	systemctl --all --type=service > $OUTPUT/$OUTDIR/Persistence/$OUTFILE-systemctl_service_status.txt
+	echo "This file might be empty as Latest versions of Red Hat, Fedora and Centos do not use service command. If this is empty please review systemctl file. " > $OUTROOT/$OUTDIR/Persistence/$OUTFILE-service_status.txt
+	service --status-all >> $OUTROOT/$OUTDIR/Persistence/$OUTFILE-service_status.txt
+	systemctl --all --type=service > $OUTROOT/$OUTDIR/Persistence/$OUTFILE-systemctl_service_status.txt
 	
 	echo "      Collecting status for all installed unit files..."
-	systemctl list-unit-files >> $OUTPUT/$OUTDIR/Persistence/$OUTFILE-systemctl_all.txt
+	systemctl list-unit-files >> $OUTROOT/$OUTDIR/Persistence/$OUTFILE-systemctl_all.txt
 
 	echo "      Collecting systemd..." 
-	find /etc/systemd/ -name "*.service" -print0 | xargs -0 cat > $OUTPUT/$OUTDIR/Persistence/$OUTFILE-persistence-systemdlist.txt
+	find /etc/systemd/ -name "*.service" -print0 | xargs -0 cat > $OUTROOT/$OUTDIR/Persistence/$OUTFILE-persistence-systemdlist.txt
 
 }
 get_startup_files_Solaris(){ #Production
 
 	echo "      Collecting service status all..."
-	svcs -a > $OUTPUT/$OUTDIR/Persistence/$OUTFILE-service_status.txt
+	svcs -a > $OUTROOT/$OUTDIR/Persistence/$OUTFILE-service_status.txt
 	
 }
 
@@ -590,26 +633,26 @@ get_startup_files_Solaris(){ #Production
 get_cron_GNU(){ #Production
 
 	# If archive is empty there were no files in var/spool/cron/crontabs directory
-	tar -czvf $OUTPUT/$OUTDIR/Persistence/$OUTFILE-cron-folder.tar.gz /var/spool/cron > $OUTPUT/$OUTDIR/Persistence/$OUTFILE-cron-folder-list.txt
+	tar -czvf $OUTROOT/$OUTDIR/Persistence/$OUTFILE-cron-folder.tar.gz /var/spool/cron > $OUTROOT/$OUTDIR/Persistence/$OUTFILE-cron-folder-list.txt
 	
 	for user in $(grep -v "/nologin\|/sync\|/false" /etc/passwd | cut -f1 -d ':'); 
 	do 
 		echo $user 
 		crontab -u $user -l 
 		echo "ENDOFUSERCRON"
-	done &> $OUTPUT/$OUTDIR/Persistence/$OUTFILE-cron-tab-list.txt
+	done &> $OUTROOT/$OUTDIR/Persistence/$OUTFILE-cron-tab-list.txt
 
 }
 get_cron_Solaris(){ #Production
 
 	# If archive is empty there were no files in var/spool/cron/crontabs directory
-	tar -czvf $OUTPUT/$OUTDIR/Persistence/$OUTFILE-cron-folder.tar.gz /var/spool/cron > $OUTPUT/$OUTDIR/Persistence/$OUTFILE-cron-folder-list.txt
+	tar -czvf $OUTROOT/$OUTDIR/Persistence/$OUTFILE-cron-folder.tar.gz /var/spool/cron > $OUTROOT/$OUTDIR/Persistence/$OUTFILE-cron-folder-list.txt
 	
 	for user in $(grep "/bash" /etc/passwd | cut -f1 -d ':'); 
 	do 
 		echo $user
 		crontab -l $user 2>/dev/null
-	done &> $OUTPUT/$OUTDIR/Persistence/$OUTFILE-cron-tab-list.txt
+	done &> $OUTROOT/$OUTDIR/Persistence/$OUTFILE-cron-tab-list.txt
 
 }
 
@@ -621,7 +664,7 @@ get_cron_Solaris(){ #Production
 #
 get_executables(){ #Production
 
-    find / -type f -perm -o+rx -print0 | xargs -0 sha1sum > $OUTPUT/$OUTDIR/Misc/$OUTFILE-exec-perm-files.txt
+    find / -type f -perm -o+rx -print0 | xargs -0 sha1sum > $OUTROOT/$OUTDIR/Misc/$OUTFILE-exec-perm-files.txt
 
 }
 
@@ -631,12 +674,12 @@ get_executables(){ #Production
 get_suspicios_data(){ #Production
 
 	#Find files in dev dir directory. Not common. Might be empty if none found
-	find /dev/ -type f -print0 | xargs -0 file 2>/dev/null > $OUTPUT/$OUTDIR/Misc/$OUTFILE-dev-dir-files.txt
+	find /dev/ -type f -print0 | xargs -0 file 2>/dev/null > $OUTROOT/$OUTDIR/Misc/$OUTFILE-dev-dir-files.txt
 	#If no found there will be single entry with d41d8cd98f00b204e9800998ecf8427e - 
-	find /dev/ -type f -print0 | xargs -0 sha1sum > $OUTPUT/$OUTDIR/Misc/$OUTFILE-dev-dir-files-hashes.txt
+	find /dev/ -type f -print0 | xargs -0 sha1sum > $OUTROOT/$OUTDIR/Misc/$OUTFILE-dev-dir-files-hashes.txt
 
 	#Find potential privilege escalation binaries/modifications (all Setuid Setguid binaries)
-	find / -xdev -type f \( -perm -04000 -o -perm -02000 \) > $OUTPUT/$OUTDIR/Misc/$OUTFILE-Setuid-Setguid-tools.txt
+	find / -xdev -type f \( -perm -04000 -o -perm -02000 \) > $OUTROOT/$OUTDIR/Misc/$OUTFILE-Setuid-Setguid-tools.txt
 }
 
 #
@@ -644,9 +687,9 @@ get_suspicios_data(){ #Production
 # 
 get_pot_webshell(){ #Production
     
-    find / -xdev -type f \( -iname '*.jsp' -o -iname '*.asp' -o -iname '*.php' -o -iname '*.aspx' \) 2>/dev/null -print0 | xargs -0 sha1sum > $OUTPUT/$OUTDIR/Misc/$OUTFILE-pot-webshell-hashes.txt
+    find / -xdev -type f \( -iname '*.jsp' -o -iname '*.asp' -o -iname '*.php' -o -iname '*.aspx' \) 2>/dev/null -print0 | xargs -0 sha1sum > $OUTROOT/$OUTDIR/Misc/$OUTFILE-pot-webshell-hashes.txt
     
-    find / -xdev -type f \( -iname '*.jsp' -o -iname '*.asp' -o -iname '*.php' -o -iname '*.aspx' \) 2>/dev/null -print0 | xargs -0 head -1000 > $OUTPUT/$OUTDIR/Misc/$OUTFILE-pot-webshell-first-1000.txt
+    find / -xdev -type f \( -iname '*.jsp' -o -iname '*.asp' -o -iname '*.php' -o -iname '*.aspx' \) 2>/dev/null -print0 | xargs -0 head -1000 > $OUTROOT/$OUTDIR/Misc/$OUTFILE-pot-webshell-first-1000.txt
     
 }
 	
@@ -658,23 +701,23 @@ end_collection(){ #Production
 	# Archive/Compress files
 	echo " "
 	echo " Creating $OUTFILE.tar.gz "
-	tar -czf $OUTPUT/$OUTFILE_PREFIX$OUTFILE.tar.gz $OUTPUT/$OUTDIR
+	tar -czf $OUTROOT/$OUTFILE_PREFIX$OUTFILE.tar.gz $OUTROOT/$OUTDIR
 	
 	# Clean-up $OUTDIR directory if the tar exists
-	if [ -f $OUTPUT/$OUTFILE_PREFIX$OUTFILE.tar.gz ]; then
+	if [ -f $OUTROOT/$OUTFILE_PREFIX$OUTFILE.tar.gz ]; then
 	 echo " "
 	 echo " Cleaning up!..."
-	 rm -r $OUTPUT/$OUTDIR
+	 rm -r $OUTROOT/$OUTDIR
 	fi
 	
 	# Check if clean-up has been successful
-	if [ ! -d $OUTPUT/$OUTDIR ]; then
+	if [ ! -d $OUTROOT/$OUTDIR ]; then
 	 echo " Clean-up Successful!"
 	fi
-	if [ -d $OUTPUT/$OUTDIR ]; then
+	if [ -d $OUTROOT/$OUTDIR ]; then
 	 echo " "
 	 echo " WARNING Clean-up has not been successful please manually remove;"
-	 echo $OUTPUT/$OUTDIR
+	 echo $OUTROOT/$OUTDIR
 	fi
 	
 	# SHA1 the tar
@@ -684,7 +727,7 @@ end_collection(){ #Production
 	 echo "  Please submit the following file and SHA1 hash for analysis."
 	 echo " *************************************************************"
 	 echo " "
-	sha1sum $OUTPUT/$OUTFILE_PREFIX$OUTFILE.tar.gz
+	sha1sum $OUTROOT/$OUTFILE_PREFIX$OUTFILE.tar.gz
 	 echo " "
 }
 
@@ -732,7 +775,7 @@ case $oscheck in
 			get_pot_webshell
 			
 			
-		} 2>> $OUTPUT/$OUTDIR/$OUTFILE-console-error-log.txt
+		} 2>> $OUTROOT/$OUTDIR/$OUTFILE-console-error-log.txt
 		;;
 	*"red hat"*|*rhel*|*fedora*|*centos*)
 		#Red Hat\Centos\Fedora
@@ -770,7 +813,7 @@ case $oscheck in
 			echo " - Hashing potential webshells..."
 			get_pot_webshell
 			
-		} 2>> $OUTPUT/$OUTDIR/$OUTFILE-console-error-log.txt
+		} 2>> $OUTROOT/$OUTDIR/$OUTFILE-console-error-log.txt
 		;;
 	*sunos*|*solaris*)
 		#SunOS/Solaris
@@ -808,7 +851,7 @@ case $oscheck in
 			echo " - Hashing potential webshells..."
 			get_pot_webshell
 			
-		} 2>> $OUTPUT/$OUTDIR/$OUTFILE-console-error-log.txt
+		} 2>> $OUTROOT/$OUTDIR/$OUTFILE-console-error-log.txt
 		;;
 	*)
 		#Incompatible Distribution
@@ -845,7 +888,7 @@ case $oscheck in
 			echo " - Hashing potential webshells..."
 			get_pot_webshell
 			
-		} 2>> $OUTPUT/$OUTDIR/$OUTFILE-console-error-log.txt
+		} 2>> $OUTROOT/$OUTDIR/$OUTFILE-console-error-log.txt
         ;;
 		
 esac

--- a/Cat-Scale.sh
+++ b/Cat-Scale.sh
@@ -29,13 +29,12 @@
 function usage {
 cat << EOF
 
-Usage: $0 [-d OUTDIR ] [-f OUTFILE ] [ -o OUTROOT ] [-p OUTFILE_PREFIX ]
+Usage: sudo $0 [-d OUTDIR ] [-f OUTFILE ] [ -o OUTROOT ] [-p OUTFILE_PREFIX ]
 
-OUTROOT - Root directory/filesystem for output to be staged (Ex. /tmp)
-OUTDIR - Directory where output will be staged while running CatScale (Ex. catscale)
-OUTFILE_PREFIX - Prefix to use for tarfile (Ex. cs_)
-OUTFILE - Name of resultant tarfile created by catscale (.gz will be appended by the script) (Ex. mytarfile)
-
+ -d	OUTDIR, Optional, Directory where output will be staged while running CatScale. Overwrites default, which is "catscale_out" 
+ -f	OUTFILE, Optional, Name of resultant archive file created by CatScale (.tar.gz will be appended by the script). Overwrites default, which is "catscale_$(hostname -s)-$date +"%Y%m%d-%H%M")"
+ -o	OUTROOT, Optional, Root directory/filesystem for output to be saved. Overwrites default, which is "$(pwd)" 
+ -p	OUTFILE_PREFIX, Optional, Prefix to use for archive file. Overwrites default, which is "catscale_"
 
 EOF
 }

--- a/Cat-Scale.sh
+++ b/Cat-Scale.sh
@@ -29,7 +29,7 @@
 function usage {
 cat << EOF
 
-Usage: sudo $0 [-d OUTDIR ] [-f OUTFILE ] [ -o OUTROOT ] [-p OUTFILE_PREFIX ]
+Usage: sudo $0 [ -d OUTDIR ] [ -f OUTFILE ] [ -o OUTROOT ] [ -p OUTFILE_PREFIX ]
 
  -d	OUTDIR, Optional, Directory where output will be staged while running CatScale. Overwrites default, which is "catscale_out" 
  -f	OUTFILE, Optional, Name of resultant archive file created by CatScale (.tar.gz will be appended by the script). Overwrites default, which is "catscale_$(hostname -s)-$date +"%Y%m%d-%H%M")"


### PR DESCRIPTION
This PR provides the ability to set custom values for the `OUTFILE` and `OUTPUT` variables (while leaving the previous defaults as-is if nothing else is specified), and also adds two new variables:

`OUTFILE_PREFIX` - Allows for replacement of `catscale_` with something else for the final tar file prefix.
`OUTDIR`: Allows for replacing `catscale_out` with something else to act as the directory where files will be transferred before creating the final tar file.

Example of running with new/updated variables:

`sudo OUTPUT=/tmp OUTDIR=mynewoutputdirname OUTFILE_PREFIX=cs_ OUTFILE=blahblah ./Cat-Scale.sh`